### PR TITLE
feat: support limited precisions in timestamps

### DIFF
--- a/internal/pkg/metadb/timestamps.go
+++ b/internal/pkg/metadb/timestamps.go
@@ -46,16 +46,19 @@ type Timestamps struct {
 var _ datastore.PropertyLoadSaver = new(Timestamps)
 
 // NewTimestamps sets CreatedAt and UpdatedAt to time.Now() and Signature to uuid.New().
-func (t *Timestamps) NewTimestamps() {
-	now := time.Now()
+func (t *Timestamps) NewTimestamps(d time.Duration) {
+	// This needs to be the lowest precision of all backend that MetaDB currently
+	// supports. Currently it's 1 microsecond.
+	// Datastore: 1 microsecond: https://cloud.google.com/datastore/docs/concepts/entities#date_and_time
+	now := time.Now().UTC().Truncate(d)
 	t.CreatedAt = now
 	t.UpdatedAt = now
 	t.Signature = uuid.New()
 }
 
 // UpdateTimestamps updates the UpdatedAt and Signature fields with time.Now() and uuid.New().
-func (t *Timestamps) UpdateTimestamps() {
-	t.UpdatedAt = time.Now()
+func (t *Timestamps) UpdateTimestamps(d time.Duration) {
+	t.UpdatedAt = time.Now().UTC().Truncate(d)
 	t.Signature = uuid.New()
 }
 


### PR DESCRIPTION

**What type of PR is this?**

> /kind feat


**What this PR does / Why we need it**:
Cloud Datastore supports up to 1 microseconds with the timestamp value. The Timestamps struct need to support different precisions for different backgrounds to keep the internal state consistent with the data stored in the backend.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
