### PR TITLE
fix: keep old CreatedAt value in UpdateRecord

### DIFF
--- a/internal/app/server/triton_test.go
+++ b/internal/app/server/triton_test.go
@@ -300,6 +300,7 @@ func updateRecordSimple(ctx context.Context, t *testing.T, client pb.TritonClien
 		UpdatedAt: timestamppb.Now(),
 	}
 	assertEqualRecord(t, expected, record)
+	assert.True(t, created.GetCreatedAt().AsTime().Equal(record.GetCreatedAt().AsTime()))
 	assert.NotEqual(t, record.GetCreatedAt().AsTime(), record.GetUpdatedAt().AsTime())
 	assert.True(t, beforeUpdate.Before(record.GetUpdatedAt().AsTime()))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/triton/blob/master/docs/contributing.md and developer guide https://github.com/googleforgames/triton/blob/master/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
/kind fix

**What this PR does / Why we need it**:
This PR fixes a bug where CreatedAt was destroyed in UpdateRecord.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #105 

**Special notes for your reviewer**:
