### PR TITLE
refactor: delete include grpc-gateway from protoc commandline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ internal/pkg/metadb/mock/mock_metadb.go: internal/pkg/metadb/metadb.go
 
 ${API_DIR}/triton.pb.go: ${API_DIR}/triton.proto
 	$(PROTOC) -I. \
-  		-I${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
  		--go_out=plugins=grpc:. \
 		--go_opt=paths=source_relative \
   		$<


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/triton/blob/master/docs/contributing.md and developer guide https://github.com/googleforgames/triton/blob/master/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
/kind refactor

**What this PR does / Why we need it**:
This PR removes the unused command line option to include grpc-gateway googleapi proto files when invoking protoc. It is a leftover from #79.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
