### PR TITLE
fix: Use metadb.Record for cache serialization

### DIFF
--- a/internal/app/server/open-saves.go
+++ b/internal/app/server/open-saves.go
@@ -231,11 +231,11 @@ func (s *openSavesServer) getRecordFromCache(ctx context.Context, key string) (*
 		return nil, err
 	}
 	log.Debugf("cache hit: %+v", re)
-	return re, nil
+	return re.ToProto(), nil
 }
 
 func (s *openSavesServer) storeRecordInCache(ctx context.Context, key string, rp *pb.Record) {
-	by, err := cache.EncodeRecord(rp)
+	by, err := cache.EncodeRecord(metadb.NewRecordFromProto(rp))
 	if err != nil {
 		// Cache fails should be logged but not return error.
 		log.Warnf("failed to encode record for cache for key (%s): %v", key, err)

--- a/internal/pkg/cache/cache_test.go
+++ b/internal/pkg/cache/cache_test.go
@@ -18,68 +18,50 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
 	pb "github.com/googleforgames/open-saves/api"
+	m "github.com/googleforgames/open-saves/internal/pkg/metadb"
+	"github.com/googleforgames/open-saves/internal/pkg/metadb/metadbtest"
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	// The threshold of comparing times.
-	// Since the server and client run on the same host for these tests,
-	// 1 second should be enough.
-	timestampDelta = 1 * time.Second
-)
-
 func TestCache_SerializeRecord(t *testing.T) {
-	rr := []*pb.Record{
+	rr := []*m.Record{
 		{
-			CreatedAt: &timestamp.Timestamp{
-				Seconds: 100,
-			},
-			UpdatedAt: &timestamp.Timestamp{
-				Seconds: 110,
+			Timestamps: m.Timestamps{
+				CreatedAt: time.Unix(100, 0),
+				UpdatedAt: time.Unix(110, 0),
 			},
 		},
 		{
 			Key: "some-key",
-			Properties: map[string]*pb.Property{
+			Properties: m.PropertyMap{
 				"prop1": {
-					Type: pb.Property_BOOLEAN,
-					Value: &pb.Property_BooleanValue{
-						BooleanValue: false,
-					},
+					Type:         pb.Property_BOOLEAN,
+					BooleanValue: false,
 				},
 				"prop2": {
-					Type: pb.Property_INTEGER,
-					Value: &pb.Property_IntegerValue{
-						IntegerValue: 200,
-					},
+					Type:         pb.Property_INTEGER,
+					IntegerValue: 200,
 				},
 				"prop3": {
-					Type: pb.Property_STRING,
-					Value: &pb.Property_StringValue{
-						StringValue: "string value",
-					},
+					Type:        pb.Property_STRING,
+					StringValue: "string value",
 				},
 			},
-			CreatedAt: &timestamp.Timestamp{
-				Seconds: 100,
-			},
-			UpdatedAt: &timestamp.Timestamp{
-				Seconds: 110,
+			Timestamps: m.Timestamps{
+				CreatedAt: time.Unix(100, 0),
+				UpdatedAt: time.Unix(110, 0),
 			},
 		},
 		{
 			Key:      "some-key",
 			Blob:     []byte("some-bytes"),
 			BlobSize: 64,
-			OwnerId:  "new-owner",
+			OwnerID:  "new-owner",
 			Tags:     []string{"tag1", "tag2"},
-			CreatedAt: &timestamp.Timestamp{
-				Seconds: 100,
-			},
-			UpdatedAt: &timestamp.Timestamp{
-				Seconds: 110,
+			Timestamps: m.Timestamps{
+				CreatedAt: time.Unix(100, 0),
+				UpdatedAt: time.Unix(110, 0),
 			},
 		},
 	}
@@ -89,34 +71,6 @@ func TestCache_SerializeRecord(t *testing.T) {
 		assert.NoError(t, err)
 		d, err := DecodeRecord(e)
 		assert.NoError(t, err)
-		assertEqualRecord(t, r, d)
-	}
-}
-
-func assertEqualRecord(t *testing.T, expected, actual *pb.Record) {
-	if expected == nil {
-		assert.Nil(t, actual)
-		return
-	}
-	if assert.NotNil(t, actual) {
-		assert.Equal(t, expected.Key, actual.Key)
-		assert.Equal(t, expected.Blob, actual.Blob)
-		assert.Equal(t, expected.BlobSize, actual.BlobSize)
-		assert.Equal(t, expected.Tags, actual.Tags)
-		assert.Equal(t, expected.OwnerId, actual.OwnerId)
-		assert.Equal(t, len(expected.Properties), len(actual.Properties))
-		for k, v := range expected.Properties {
-			if assert.Contains(t, actual.Properties, k) {
-				av := actual.Properties[k]
-				assert.Equal(t, v.Type, av.Type)
-				assert.Equal(t, v.Value, av.Value)
-			}
-		}
-		assert.NotNil(t, actual.GetCreatedAt())
-		assert.WithinDuration(t, expected.GetUpdatedAt().AsTime(),
-			actual.GetUpdatedAt().AsTime(), timestampDelta)
-		assert.NotNil(t, actual.GetUpdatedAt())
-		assert.WithinDuration(t, expected.GetUpdatedAt().AsTime(),
-			actual.GetUpdatedAt().AsTime(), timestampDelta)
+		metadbtest.AssertEqualRecord(t, r, d)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/master/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/master/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
/kind fix

**What this PR does / Why we need it**:
Store metadb.Record instead of pb.Record in the redis cache. They are independent from the public API and smaller.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
