### PR TITLE
refactor: change BlobRef.Initialize to NewBlobRef

### DIFF
--- a/internal/pkg/metadb/blob.go
+++ b/internal/pkg/metadb/blob.go
@@ -108,18 +108,13 @@ func (b *BlobRef) LoadKey(k *datastore.Key) error {
 	return err
 }
 
-// Initialize sets up the Blob as follows:
+// NewBlobRef creates a new BlobRef as follows:
 //	- Set a new UUID to Key
 //	- Initialize Size and ObjectName as specified
 //	- Set Status to BlobRefStatusInitializing
 //	- Set current time to Timestamps (both created and updated at)
-//
-// Initialize should be called once on a zero-initialized (empty) BlobRef whose
-// Status is set to BlobRefStatusUnknown, otherwise it returns an error.
-func (b *BlobRef) Initialize(size int64, storeKey, recordKey, objectName string) error {
-	if b.Status != BlobRefStatusUnknown {
-		return errors.New("cannot re-initialize a blob entry")
-	}
+func NewBlobRef(size int64, storeKey, recordKey, objectName string) *BlobRef {
+	b := new(BlobRef)
 	b.Key = uuid.New()
 	b.Size = size
 	b.ObjectName = objectName
@@ -128,7 +123,7 @@ func (b *BlobRef) Initialize(size int64, storeKey, recordKey, objectName string)
 	b.RecordKey = recordKey
 	// Nanosecond is fine as it will not be returned to clients.
 	b.Timestamps.NewTimestamps(time.Nanosecond)
-	return nil
+	return b
 }
 
 // Ready changes Status to BlobRefStatusReady and updates Timestamps.

--- a/internal/pkg/metadb/blob_test.go
+++ b/internal/pkg/metadb/blob_test.go
@@ -120,7 +120,6 @@ func TestBlobRef_Load(t *testing.T) {
 }
 
 func newInitBlob(t *testing.T) *m.BlobRef {
-	blob := new(m.BlobRef)
 	const (
 		size   = int64(4)
 		name   = "abc"
@@ -129,7 +128,10 @@ func newInitBlob(t *testing.T) *m.BlobRef {
 	)
 
 	// Initialize
-	assert.NoError(t, blob.Initialize(size, store, record, name))
+	blob := m.NewBlobRef(size, store, record, name)
+	if blob == nil {
+		t.Fatal("NewBlobRef returned nil.")
+	}
 	assert.NotEqual(t, uuid.Nil, blob.Key)
 	assert.Equal(t, size, blob.Size)
 	assert.Equal(t, name, blob.ObjectName)
@@ -145,9 +147,6 @@ func newInitBlob(t *testing.T) *m.BlobRef {
 func TestBlobRef_LifeCycle(t *testing.T) {
 	blob := newInitBlob(t)
 
-	// Invalid transition
-	assert.Error(t, blob.Initialize(0, "", "", ""))
-
 	// Mark for deletion
 	assert.NoError(t, blob.MarkForDeletion())
 	assert.Equal(t, m.BlobRefStatusPendingDeletion, blob.Status)
@@ -160,7 +159,6 @@ func TestBlobRef_LifeCycle(t *testing.T) {
 	assert.Equal(t, m.BlobRefStatusReady, blob.Status)
 
 	// Invalid transitions
-	assert.Error(t, blob.Initialize(0, "", "", ""))
 	assert.Error(t, blob.Ready())
 
 	// Mark for deletion
@@ -170,7 +168,6 @@ func TestBlobRef_LifeCycle(t *testing.T) {
 	// Invalid transitions
 	assert.Error(t, blob.MarkForDeletion())
 	assert.Error(t, blob.Ready())
-	assert.Error(t, blob.Initialize(0, "", "", ""))
 }
 
 func TestBlobRef_Fail(t *testing.T) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/master/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/master/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**

/kind refactor


**What this PR does / Why we need it**:
This PR changes BlobRef.Initialize to a non-member function NewBlobRef.
It ensures the initialization happens once and only once.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
