### PR TITLE
feature: RemoveBlobFromRecord removes inline blob

### DIFF
--- a/internal/pkg/metadb/datastore/datastore_test.go
+++ b/internal/pkg/metadb/datastore/datastore_test.go
@@ -405,9 +405,9 @@ func TestDriver_SimpleCreateGetDeleteBlobRef(t *testing.T) {
 		assert.Equal(t, codes.FailedPrecondition, grpc.Code(err))
 	}
 
-	delPendRecord, delPendBlob, err := driver.MarkBlobRefForDeletion(ctx, storeKey, recordKey)
+	delPendRecord, delPendBlob, err := driver.RemoveBlobFromRecord(ctx, storeKey, recordKey)
 	if err != nil {
-		t.Errorf("MarkBlobForDeletion failed: %v", err)
+		t.Errorf("RemoveBlobFromRecord failed: %v", err)
 	} else {
 		if assert.NotNil(t, delPendRecord) {
 			assert.Equal(t, uuid.Nil, delPendRecord.ExternalBlob)
@@ -489,7 +489,7 @@ func TestDriver_SwapBlobRefs(t *testing.T) {
 		}
 	}
 
-	_, _, err = driver.MarkBlobRefForDeletion(ctx, store.Key, record.Key)
+	_, _, err = driver.RemoveBlobFromRecord(ctx, store.Key, record.Key)
 	assert.NoError(t, err)
 }
 

--- a/internal/pkg/metadb/metadb.go
+++ b/internal/pkg/metadb/metadb.go
@@ -44,7 +44,7 @@ type Driver interface {
 	GetBlobRef(ctx context.Context, key uuid.UUID) (*BlobRef, error)
 	GetCurrentBlobRef(ctx context.Context, storeKey, recordKey string) (*BlobRef, error)
 	PromoteBlobRefToCurrent(ctx context.Context, blob *BlobRef) (*Record, *BlobRef, error)
-	MarkBlobRefForDeletion(ctx context.Context, storeKey string, recordKey string) (*Record, *BlobRef, error)
+	RemoveBlobFromRecord(ctx context.Context, storeKey string, recordKey string) (*Record, *BlobRef, error)
 	DeleteBlobRef(ctx context.Context, key uuid.UUID) error
 
 	TimestampPrecision() time.Duration
@@ -174,15 +174,15 @@ func (m *MetaDB) PromoteBlobRefToCurrent(ctx context.Context, blob *BlobRef) (*R
 	return m.driver.PromoteBlobRefToCurrent(ctx, blob)
 }
 
-// MarkBlobRefForDeletion removes the ExternalBlob from the record specified by
+// RemoveBlobFromRecord removes the ExternalBlob from the record specified by
 // storeKey and recordKey. It also changes the status of the blob object to
 // BlobRefStatusPendingDeletion.
 // Returned errors:
 //	- NotFound: the specified record or the blobref was not found
 //	- FailedPrecondition: the record doesn't have an external blob
 //  - Internal: BlobRef status transition error
-func (m *MetaDB) MarkBlobRefForDeletion(ctx context.Context, storeKey string, recordKey string) (*Record, *BlobRef, error) {
-	return m.driver.MarkBlobRefForDeletion(ctx, storeKey, recordKey)
+func (m *MetaDB) RemoveBlobFromRecord(ctx context.Context, storeKey string, recordKey string) (*Record, *BlobRef, error) {
+	return m.driver.RemoveBlobFromRecord(ctx, storeKey, recordKey)
 }
 
 // DeleteBlobRef deletes the BlobRef object from the database.

--- a/internal/pkg/metadb/metadb_test.go
+++ b/internal/pkg/metadb/metadb_test.go
@@ -138,8 +138,8 @@ func TestMetaDB_DriverCalls(t *testing.T) {
 	assert.Same(t, blob, actualBlob)
 	assert.NoError(t, err)
 
-	mockDriver.EXPECT().MarkBlobRefForDeletion(ctx, key, key2).Return(record, blob, nil)
-	actualrecord, actualBlob, err = metadb.MarkBlobRefForDeletion(ctx, key, key2)
+	mockDriver.EXPECT().RemoveBlobFromRecord(ctx, key, key2).Return(record, blob, nil)
+	actualrecord, actualBlob, err = metadb.RemoveBlobFromRecord(ctx, key, key2)
 	assert.Same(t, record, actualrecord)
 	assert.Same(t, blob, actualBlob)
 	assert.NoError(t, err)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/master/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/master/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
/kind feat


**What this PR does / Why we need it**:
MetaDB.RemoveBlobFromRecord now removes inline blobs.
MetaDB.MarkBlobRefForDeletion has been renamed to RemoveBlobFromRecord and
now removed an inline blob too.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
