### PR TITLE
feature: MetaDB.ListBlobRefsByStatus

### DIFF
--- a/deploy/terraform/gcp/datastore.tf
+++ b/deploy/terraform/gcp/datastore.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_datastore_index" "blob_status_updated_at" {
+  kind = "blob"
+  properties {
+    name = "Status"
+    direction = "ASCENDING"
+  }
+  properties {
+    name = "Timestamps.UpdatedAt"
+    direction = "ASCENDING"
+  }
+}

--- a/internal/pkg/metadb/blob.go
+++ b/internal/pkg/metadb/blob.go
@@ -157,3 +157,10 @@ func (b *BlobRef) Fail() error {
 func (b *BlobRef) ObjectPath() string {
 	return b.Key.String()
 }
+
+// BlobRefCursor is a database cursor for BlobRef.
+type BlobRefCursor interface {
+	// Next advances the iterator and returns the next value.
+	// Returns nil and an iterator.Done at the end of the iterator.
+	Next() (*BlobRef, error)
+}

--- a/internal/pkg/metadb/datastore/cursor.go
+++ b/internal/pkg/metadb/datastore/cursor.go
@@ -1,0 +1,44 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"errors"
+
+	ds "cloud.google.com/go/datastore"
+	"github.com/googleforgames/open-saves/internal/pkg/metadb"
+)
+
+var _ metadb.BlobRefCursor = new(blobRefCursor)
+
+type blobRefCursor struct {
+	iter *ds.Iterator
+}
+
+func newBlobRefIterator(i *ds.Iterator) *blobRefCursor {
+	return &blobRefCursor{iter: i}
+}
+
+func (i *blobRefCursor) Next() (*metadb.BlobRef, error) {
+	if i == nil {
+		return nil, errors.New("BlobRefIterator.Next was called on nil")
+	}
+	var blob metadb.BlobRef
+	_, err := i.iter.Next(&blob)
+	if err != nil {
+		return nil, err
+	}
+	return &blob, nil
+}

--- a/internal/pkg/metadb/datastore/datastore.go
+++ b/internal/pkg/metadb/datastore/datastore.go
@@ -469,3 +469,11 @@ func (d *Driver) DeleteBlobRef(ctx context.Context, key uuid.UUID) error {
 	})
 	return datastoreErrToGRPCStatus(err)
 }
+
+// ListBlobRefsByStatus implements Driver.ListBlobRefsByStatus.
+func (d *Driver) ListBlobRefsByStatus(ctx context.Context, status m.BlobRefStatus, olderThan time.Time) (m.BlobRefCursor, error) {
+	query := d.newQuery(blobKind).Filter("Status = ", int(status)).
+		Filter("Timestamps.UpdatedAt <", olderThan)
+	iter := &blobRefCursor{d.client.Run(ctx, query)}
+	return iter, nil
+}

--- a/internal/pkg/metadb/metadb.go
+++ b/internal/pkg/metadb/metadb.go
@@ -46,6 +46,7 @@ type Driver interface {
 	PromoteBlobRefToCurrent(ctx context.Context, blob *BlobRef) (*Record, *BlobRef, error)
 	RemoveBlobFromRecord(ctx context.Context, storeKey string, recordKey string) (*Record, *BlobRef, error)
 	DeleteBlobRef(ctx context.Context, key uuid.UUID) error
+	ListBlobRefsByStatus(ctx context.Context, status BlobRefStatus, olderThan time.Time) (BlobRefCursor, error)
 
 	TimestampPrecision() time.Duration
 }
@@ -191,4 +192,10 @@ func (m *MetaDB) RemoveBlobFromRecord(ctx context.Context, storeKey string, reco
 //	- FailedPrecondition: the blobref status is Ready and can't be deleted
 func (m *MetaDB) DeleteBlobRef(ctx context.Context, key uuid.UUID) error {
 	return m.driver.DeleteBlobRef(ctx, key)
+}
+
+// ListBlobRefsByStatus returns a cursor that iterates over BlobRefs
+// where Status = status and UpdatedAt < olderThan.
+func (m *MetaDB) ListBlobRefsByStatus(ctx context.Context, status BlobRefStatus, olderThan time.Time) (BlobRefCursor, error) {
+	return m.driver.ListBlobRefsByStatus(ctx, status, olderThan)
 }

--- a/internal/pkg/metadb/metadb_test.go
+++ b/internal/pkg/metadb/metadb_test.go
@@ -146,4 +146,10 @@ func TestMetaDB_DriverCalls(t *testing.T) {
 
 	mockDriver.EXPECT().DeleteBlobRef(ctx, aUUID)
 	assert.NoError(t, metadb.DeleteBlobRef(ctx, aUUID))
+
+	olderThan := time.Unix(123456, 0)
+	mockDriver.EXPECT().ListBlobRefsByStatus(ctx, m.BlobRefStatusPendingDeletion, olderThan).Return(nil, nil)
+	iter, err := metadb.ListBlobRefsByStatus(ctx, m.BlobRefStatusPendingDeletion, olderThan)
+	assert.Nil(t, iter)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/master/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/master/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**

/kind feat

**What this PR does / Why we need it**:
This PR adds MetaDB.ListBlobRefsByStatus that returns BlobRef entries based on Status (i.g. marked for deletion).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
The actual garbage collector implementation will be added later.
