### PR TITLE
fix: remove redis test's empty database prerequisite

### DIFF
--- a/internal/pkg/cache/redis_test.go
+++ b/internal/pkg/cache/redis_test.go
@@ -33,6 +33,8 @@ func TestRedis_All(t *testing.T) {
 	// invocation.
 	r := NewRedis("localhost:6379")
 
+	assert.NoError(t, r.FlushAll(ctx))
+
 	keys, err := r.ListKeys(ctx)
 	assert.NoError(t, err)
 	assert.Empty(t, keys)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/main/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/main/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
> /kind fix

**What this PR does / Why we need it**:
Adds a flushall before running Redis test so it's not dependent on
being empty prior to running the test

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #190

**Special notes for your reviewer**:
