### PR TITLE
refactor: replace grpc.* error funcs with status.*

### DIFF
--- a/internal/app/collector/collector_test.go
+++ b/internal/app/collector/collector_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/googleforgames/open-saves/internal/pkg/metadb/store"
 	"github.com/stretchr/testify/assert"
 	"gocloud.dev/gcerrors"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -163,7 +163,7 @@ func TestCollector_DeletesBlobs(t *testing.T) {
 			assert.NoError(t, err)
 		} else {
 			assert.Nil(t, actual)
-			assert.Equal(t, codes.NotFound, grpc.Code(err))
+			assert.Equal(t, codes.NotFound, status.Code(err))
 		}
 		_, err = collector.blob.Get(ctx, blobRefs[i].ObjectPath())
 		if e {

--- a/internal/pkg/metadb/metadb.go
+++ b/internal/pkg/metadb/metadb.go
@@ -333,7 +333,7 @@ func (m *MetaDB) DeleteRecord(ctx context.Context, storeKey, key string) error {
 				if err != nil {
 					return err
 				}
-			} else if grpc.Code(err) != codes.NotFound {
+			} else if status.Code(err) != codes.NotFound {
 				return err
 			}
 		}

--- a/internal/pkg/metadb/metadb.go
+++ b/internal/pkg/metadb/metadb.go
@@ -25,7 +25,6 @@ import (
 	"github.com/googleforgames/open-saves/internal/pkg/metadb/store"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -256,7 +255,7 @@ func (m *MetaDB) InsertRecord(ctx context.Context, storeKey string, record *reco
 // Returns error if the store doesn't have a record with the key provided.
 func (m *MetaDB) UpdateRecord(ctx context.Context, storeKey string, key string, updater RecordUpdater) (*record.Record, error) {
 	if updater == nil {
-		return nil, grpc.Errorf(codes.Internal, "updater cannot be nil")
+		return nil, status.Errorf(codes.Internal, "updater cannot be nil")
 	}
 	var toUpdate *record.Record
 	_, err := m.client.RunInTransaction(ctx, func(tx *ds.Transaction) error {

--- a/internal/pkg/metadb/metadb_test.go
+++ b/internal/pkg/metadb/metadb_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/googleforgames/open-saves/internal/pkg/metadb/timestamps"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/iterator"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -411,7 +410,7 @@ func TestMetaDB_SimpleCreateGetDeleteBlobRef(t *testing.T) {
 	setupTestBlobRef(ctx, t, metaDB, blob)
 
 	_, err := metaDB.GetCurrentBlobRef(ctx, storeKey, recordKey)
-	assert.Equal(t, codes.FailedPrecondition, grpc.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 
 	blob2, err := metaDB.GetBlobRef(ctx, blobKey)
 	if err != nil {
@@ -450,7 +449,7 @@ func TestMetaDB_SimpleCreateGetDeleteBlobRef(t *testing.T) {
 	if err := metaDB.DeleteBlobRef(ctx, blobKey); err == nil {
 		t.Errorf("DeleteBlobRef should fail on current blob: %v", err)
 	} else {
-		assert.Equal(t, codes.FailedPrecondition, grpc.Code(err))
+		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 	}
 
 	delPendRecord, delPendBlob, err := metaDB.RemoveBlobFromRecord(ctx, storeKey, recordKey)
@@ -471,7 +470,7 @@ func TestMetaDB_SimpleCreateGetDeleteBlobRef(t *testing.T) {
 
 	deletedBlob, err := metaDB.GetBlobRef(ctx, blobKey)
 	assert.Nil(t, deletedBlob)
-	assert.Equal(t, codes.NotFound, grpc.Code(err), "GetBlobRef should return NotFound after deletion.")
+	assert.Equal(t, codes.NotFound, status.Code(err), "GetBlobRef should return NotFound after deletion.")
 }
 
 func TestMetaDB_SwapBlobRefs(t *testing.T) {
@@ -595,7 +594,7 @@ func TestMetaDB_BlobInsertShouldFailForNonexistentRecord(t *testing.T) {
 		t.Error("InsertBlobRef should fail for a non-existent record.")
 		assert.NoError(t, metaDB.DeleteBlobRef(ctx, blob.Key))
 	} else {
-		assert.Equal(t, codes.FailedPrecondition, grpc.Code(err))
+		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 		assert.Nil(t, insertedBlob)
 	}
 }
@@ -639,7 +638,7 @@ func TestMetaDB_UpdateRecordWithExternalBlobs(t *testing.T) {
 		return record, nil
 	})
 	if assert.Error(t, err, "UpdateRecord should fail when ExternalBlob is modified") {
-		assert.Equal(t, codes.Internal, grpc.Code(err))
+		assert.Equal(t, codes.Internal, status.Code(err))
 	}
 
 	// Make sure ExternalBlob is preserved when not modified
@@ -826,7 +825,7 @@ func TestMetaDB_DeleteRecordWithNonExistentBlobRef(t *testing.T) {
 	actualBlob, err := metaDB.GetBlobRef(ctx, record.ExternalBlob)
 	assert.Nil(t, actualBlob)
 	if assert.Error(t, err, "GetBlobRef should return error when BlobRef doesn't exist.") {
-		assert.Equal(t, codes.NotFound, grpc.Code(err),
+		assert.Equal(t, codes.NotFound, status.Code(err),
 			"GetBlobRef should return NotFound when BlobRef doesn't exist.")
 	}
 
@@ -837,7 +836,7 @@ func TestMetaDB_DeleteRecordWithNonExistentBlobRef(t *testing.T) {
 	actualRecord, err := metaDB.GetRecord(ctx, storeKey, recordKey)
 	assert.Nil(t, actualRecord)
 	if assert.Error(t, err, "GetRecord should return error after DeleteRecord") {
-		assert.Equal(t, codes.NotFound, grpc.Code(err),
+		assert.Equal(t, codes.NotFound, status.Code(err),
 			"GetRecord should return NotFound after DeleteRecord")
 	}
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/main/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/main/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
/kind refactor

**What this PR does / Why we need it**:
Replace grpc.Code and grpc.Errorf with status.Code and status.Errorf respectively because the functions in the grpc namespace have been deprecated and replaced by those in the status namespace.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #226 

**Special notes for your reviewer**:
