### PR TITLE
fix: server allocated buffer for entire blob size

### DIFF
--- a/internal/app/server/open_saves.go
+++ b/internal/app/server/open_saves.go
@@ -212,7 +212,7 @@ func (s *openSavesServer) insertInlineBlob(ctx context.Context, stream pb.OpenSa
 	log.Debugf("Inserting inline blob: %v\n", meta)
 	// Receive the blob
 	size := meta.GetSize()
-	buffer := bytes.NewBuffer(make([]byte, 0, size))
+	buffer := new(bytes.Buffer)
 	recvd := 0
 	for {
 		if int64(recvd) > size {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/main/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/main/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
 /kind fix


**What this PR does / Why we need it**:
This fixes a bug where the server program allocates a buffer for an entire blob object, instead of a streaming message.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
