### PR TITLE
samples: update grpc example to support no authentication

### DIFF
--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -33,6 +33,7 @@ import (
 
 var (
 	address      = flag.String("address", "localhost:6000", "Address of Open Saves server")
+	insecure     = flag.Bool("insecure", false, "Dial grpc server insecurely")
 	authenticate = flag.Bool("authenticate", false, "Dial grpc server with default authentication")
 )
 
@@ -51,6 +52,9 @@ func main() {
 		pool, _ := x509.SystemCertPool()
 		creds := credentials.NewClientTLSFromCert(pool, "")
 		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(creds)), option.WithoutAuthentication())
+	}
+	if *insecure {
+		opts = append(opts, option.WithGRPCDialOption(grpc.WithInsecure()), option.WithoutAuthentication())
 	}
 	if *address != "" {
 		opts = append(opts, option.WithEndpoint(*address))

--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"log"
@@ -25,13 +26,14 @@ import (
 	"google.golang.org/api/option"
 	gtransport "google.golang.org/api/transport/grpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	pb "github.com/googleforgames/open-saves/api"
 )
 
 var (
-	address  = flag.String("address", "localhost:6000", "Address of Open Saves server")
-	insecure = flag.Bool("insecure", false, "Dial grpc server insecurely")
+	address      = flag.String("address", "localhost:6000", "Address of Open Saves server")
+	authenticate = flag.Bool("authenticate", false, "Dial grpc server with default authentication")
 )
 
 func defaultClientOptions() []option.ClientOption {
@@ -45,8 +47,10 @@ func main() {
 	ctx := context.Background()
 
 	opts := defaultClientOptions()
-	if *insecure {
-		opts = append(opts, option.WithGRPCDialOption(grpc.WithInsecure()), option.WithoutAuthentication())
+	if !*authenticate {
+		pool, _ := x509.SystemCertPool()
+		creds := credentials.NewClientTLSFromCert(pool, "")
+		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(creds)), option.WithoutAuthentication())
 	}
 	if *address != "" {
 		opts = append(opts, option.WithEndpoint(*address))


### PR DESCRIPTION
**What type of PR is this?**
/kind docs

**What this PR does / Why we need it**:
Currently, the example does not work properly if `GOOGLE_APPLICATION_CREDENTIALS` is set. With the new `authenticate` flag, we dial the gRPC connection without authentication.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
