### PR TITLE
fix: crash in CreateChunkedBlob with invalid param

### DIFF
--- a/internal/app/server/open_saves.go
+++ b/internal/app/server/open_saves.go
@@ -471,7 +471,7 @@ func (s *openSavesServer) CreateChunkedBlob(ctx context.Context, req *pb.CreateC
 	b := blobref.NewChunkedBlobRef(req.GetStoreKey(), req.GetRecordKey())
 	b, err := s.metaDB.InsertBlobRef(ctx, b)
 	if err != nil {
-		log.Errorf("CreateChunkedBlob failed for record (%v), blob key (%v): %v", b.RecordKey, b.Key, err)
+		log.Errorf("CreateChunkedBlob failed for store (%v), record (%v): %v", req.GetStoreKey(), req.GetRecordKey(), err)
 		return nil, err
 	}
 	return &pb.CreateChunkedBlobResponse{

--- a/internal/app/server/open_saves_test.go
+++ b/internal/app/server/open_saves_test.go
@@ -885,3 +885,18 @@ func TestOpenSaves_QueryRecords_Tags(t *testing.T) {
 
 	assert.Contains(t, resp.Records[0].Tags, "hello")
 }
+
+func TestOpenSaves_CreateChunkedBlobNonExistent(t *testing.T) {
+	ctx := context.Background()
+	_, listener := getOpenSavesServer(ctx, t, "gcp")
+	_, client := getTestClient(ctx, t, listener)
+	// Non-existent record should fail with codes.FailedPrecondition
+
+	res, err := client.CreateChunkedBlob(ctx, &pb.CreateChunkedBlobRequest{
+		StoreKey:  uuid.NewString(),
+		RecordKey: uuid.NewString(),
+		ChunkSize: 0,
+	})
+	assert.Nil(t, res)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}

--- a/internal/app/server/open_saves_test.go
+++ b/internal/app/server/open_saves_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/iterator"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -860,8 +862,8 @@ func TestOpenSaves_CreateChunkedBlobNonExistent(t *testing.T) {
 	ctx := context.Background()
 	_, listener := getOpenSavesServer(ctx, t, "gcp")
 	_, client := getTestClient(ctx, t, listener)
-	// Non-existent record should fail with codes.FailedPrecondition
 
+	// Non-existent record should fail with codes.FailedPrecondition
 	res, err := client.CreateChunkedBlob(ctx, &pb.CreateChunkedBlobRequest{
 		StoreKey:  uuid.NewString(),
 		RecordKey: uuid.NewString(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/main/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/main/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
 /kind fix

**What this PR does / Why we need it**:
Fix a crash bug when an invalid parameter was passed to CreateChunkedBlob.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #281 

**Special notes for your reviewer**:
Proper tests will be added later but want to fix this crash bug first.