### PR TITLE
fix: wrong CRC32C checksums error message

### DIFF
--- a/internal/pkg/metadb/checksums/checksums.go
+++ b/internal/pkg/metadb/checksums/checksums.go
@@ -72,7 +72,7 @@ func (c *Checksums) ValidateIfPresent(p ChecksumsProto) error {
 		if p.GetCrc32C() != c.GetCRC32C() {
 			return status.Errorf(codes.DataLoss,
 				"CRC32C checksums didn't match: provided[%v], calculated[%v]",
-				p.GetCrc32C(), p.GetCrc32C())
+				p.GetCrc32C(), c.GetCRC32C())
 		}
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind fix

**What this PR does / Why we need it**:
Fix wrong CRC32C error messages currently returning the received proto value
