### PR TITLE
fix: retry redis operation on broken pipe error

### DIFF
--- a/internal/pkg/cache/redis/redis.go
+++ b/internal/pkg/cache/redis/redis.go
@@ -16,9 +16,13 @@ package redis
 
 import (
 	"context"
+	"errors"
+	"syscall"
 
 	"github.com/gomodule/redigo/redis"
 )
+
+const BrokenPipeRetries = 3
 
 // Redis is an implementation of the cache.Cache interface.
 type Redis struct {
@@ -41,60 +45,123 @@ func NewRedis(address string, opts ...redis.DialOption) *Redis {
 
 // Set adds a key-value pair to the redis instance.
 func (r *Redis) Set(ctx context.Context, key string, value []byte) error {
-	conn := r.redisPool.Get()
-	defer conn.Close()
+	return retryOnBrokenPipe(BrokenPipeRetries, func() error {
+		conn, err := r.redisPool.GetContext(ctx)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
 
-	_, err := conn.Do("SET", key, value)
-	if err != nil {
-		return err
-	}
-	return nil
+		_, err = conn.Do("SET", key, value)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 // Get retrieves the value for a given key.
 func (r *Redis) Get(ctx context.Context, key string) ([]byte, error) {
-	conn := r.redisPool.Get()
-	defer conn.Close()
+	return retryOnBrokenPipeBytes(BrokenPipeRetries, func() ([]byte, error) {
+		conn, err := r.redisPool.GetContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		defer conn.Close()
 
-	val, err := redis.Bytes(conn.Do("GET", key))
-	if err != nil {
-		return nil, err
-	}
-	return val, nil
+		val, err := redis.Bytes(conn.Do("GET", key))
+		if err != nil {
+			return nil, err
+		}
+		return val, nil
+	})
 }
 
 // Delete deletes the key from the redis instance.
 func (r *Redis) Delete(ctx context.Context, key string) error {
-	conn := r.redisPool.Get()
-	defer conn.Close()
+	return retryOnBrokenPipe(BrokenPipeRetries, func() error {
+		conn, err := r.redisPool.GetContext(ctx)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
 
-	_, err := conn.Do("DEL", key)
-	if err != nil {
-		return err
-	}
-	return nil
+		_, err = conn.Do("DEL", key)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 // FlushAll removes all key-value pairs from the redis instance.
 func (r *Redis) FlushAll(ctx context.Context) error {
-	conn := r.redisPool.Get()
-	defer conn.Close()
+	return retryOnBrokenPipe(BrokenPipeRetries, func() error {
+		conn, err := r.redisPool.GetContext(ctx)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
 
-	_, err := conn.Do("FLUSHALL")
-	if err != nil {
+		_, err = conn.Do("FLUSHALL")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// ListKeys lists all the keys in the redis instance.
+func (r *Redis) ListKeys(ctx context.Context) ([]string, error) {
+	return retryOnBrokenPipeStrings(BrokenPipeRetries, func() ([]string, error) {
+		conn, err := r.redisPool.GetContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		defer conn.Close()
+
+		keys, err := redis.Strings(conn.Do("KEYS", "*"))
+		if err != nil {
+			return nil, err
+		}
+		return keys, nil
+	})
+}
+
+func retryOnBrokenPipe(attempts int, fn func() error) error {
+	if err := fn(); err != nil {
+		if errors.Is(err, syscall.EPIPE) {
+			if attempts--; attempts > 0 {
+				return retryOnBrokenPipe(attempts, fn)
+			}
+		}
 		return err
 	}
 	return nil
 }
 
-// ListKeys lists all the keys in the redis instance.
-func (r *Redis) ListKeys(ctx context.Context) ([]string, error) {
-	conn := r.redisPool.Get()
-	defer conn.Close()
-
-	keys, err := redis.Strings(conn.Do("KEYS", "*"))
+func retryOnBrokenPipeBytes(attempts int, fn func() ([]byte, error)) ([]byte, error) {
+	b, err := fn()
 	if err != nil {
+		if errors.Is(err, syscall.EPIPE) {
+			if attempts--; attempts > 0 {
+				return retryOnBrokenPipeBytes(attempts, fn)
+			}
+		}
 		return nil, err
 	}
-	return keys, nil
+	return b, nil
+}
+
+func retryOnBrokenPipeStrings(attempts int, fn func() ([]string, error)) ([]string, error) {
+	s, err := fn()
+	if err != nil {
+		if errors.Is(err, syscall.EPIPE) {
+			if attempts--; attempts > 0 {
+				return retryOnBrokenPipeStrings(attempts, fn)
+			}
+		}
+		return nil, err
+	}
+	return s, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/main/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/main/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind fix

**What this PR does / Why we need it**:
When the redis connection retrieved form the pool is invalid, retry the operation (up to three times).

When this error happens, the redis cache becomes stales and does not have the latest data. This cause issues when performing PUT/PATCH operation since the signature read from Redis is stale.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #323

**Special notes for your reviewer**:
https://gosamples.dev/broken-pipe/#:~:text=Share%3A,connection%20should%20be%20terminated%20immediately.