### PR TITLE
feat!: add default expiration (5m) for Redis

### DIFF
--- a/configs/service.yaml
+++ b/configs/service.yaml
@@ -3,6 +3,7 @@ open_saves_cloud: "gcp"
 open_saves_bucket: ""
 open_saves_project: ""
 log_level: "info"
+cache_default_ttl: "5m"
 
 redis_address: "localhost:6379"
 redis_max_idle: 500

--- a/internal/app/collector/collector.go
+++ b/internal/app/collector/collector.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleforgames/open-saves/internal/pkg/blob"
 	"github.com/googleforgames/open-saves/internal/pkg/cache"
 	"github.com/googleforgames/open-saves/internal/pkg/cache/redis"
+	"github.com/googleforgames/open-saves/internal/pkg/config"
 	"github.com/googleforgames/open-saves/internal/pkg/metadb"
 	"github.com/googleforgames/open-saves/internal/pkg/metadb/blobref"
 	"github.com/googleforgames/open-saves/internal/pkg/metadb/blobref/chunkref"
@@ -64,7 +65,7 @@ func newCollector(ctx context.Context, cfg *Config) (*Collector, error) {
 			log.Fatalf("Failed to create a MetaDB instance: %v", err)
 			return nil, err
 		}
-		cache := cache.New(redis.NewRedis(cfg.Cache))
+		cache := cache.New(redis.NewRedis(cfg.Cache), &config.CacheConfig{})
 		c := &Collector{
 			blob:   gcs,
 			metaDB: metadb,

--- a/internal/app/server/open_saves.go
+++ b/internal/app/server/open_saves.go
@@ -18,8 +18,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/googleforgames/open-saves/internal/pkg/config"
 	"io"
+
+	"github.com/googleforgames/open-saves/internal/pkg/config"
 
 	"github.com/google/uuid"
 	pb "github.com/googleforgames/open-saves/api"
@@ -75,7 +76,7 @@ func newOpenSavesServer(ctx context.Context, cfg *config.ServiceConfig) (*openSa
 			log.Fatalf("Failed to create a MetaDB instance: %v", err)
 			return nil, err
 		}
-		cache := cache.New(redis.NewRedisWithConfig(&cfg.RedisConfig))
+		cache := cache.New(redis.NewRedisWithConfig(&cfg.RedisConfig), &cfg.CacheConfig)
 		server := &openSavesServer{
 			cloud:      cfg.ServerConfig.Cloud,
 			blobStore:  gcs,

--- a/internal/pkg/cache/redis/redis.go
+++ b/internal/pkg/cache/redis/redis.go
@@ -16,6 +16,7 @@ package redis
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/googleforgames/open-saves/internal/pkg/config"
@@ -52,8 +53,8 @@ func NewRedisWithConfig(cfg *config.RedisConfig) *Redis {
 }
 
 // Set adds a key-value pair to the redis instance.
-func (r *Redis) Set(ctx context.Context, key string, value []byte) error {
-	return r.c.Set(ctx, key, string(value), 0).Err()
+func (r *Redis) Set(ctx context.Context, key string, value []byte, expiration time.Duration) error {
+	return r.c.Set(ctx, key, string(value), expiration).Err()
 }
 
 // Get retrieves the value for a given key.

--- a/internal/pkg/cache/redis/redis_test.go
+++ b/internal/pkg/cache/redis/redis_test.go
@@ -17,7 +17,9 @@ package redis
 import (
 	"context"
 	"testing"
+	"time"
 
+	redis "github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,11 +41,18 @@ func TestRedis_All(t *testing.T) {
 	assert.Error(t, err)
 
 	by := []byte("byte")
-	assert.NoError(t, r.Set(ctx, "hello", by))
+	assert.NoError(t, r.Set(ctx, "hello", by, 0))
 
 	val, err := r.Get(ctx, "hello")
 	assert.NoError(t, err)
 	assert.Equal(t, by, val)
+
+	// test with TTL. The resolution is one millisecond.
+	assert.NoError(t, r.Set(ctx, "withTTL", by, 1*time.Millisecond))
+	time.Sleep(2 * time.Millisecond)
+	val, err = r.Get(ctx, "withTTL")
+	assert.ErrorIs(t, redis.Nil, err)
+	assert.Nil(t, val)
 
 	keys, err = r.ListKeys(ctx)
 	assert.NoError(t, err)

--- a/internal/pkg/config/loader.go
+++ b/internal/pkg/config/loader.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (
@@ -94,6 +108,10 @@ func Load(path string) (*ServiceConfig, error) {
 		serverConfig.Address = fmt.Sprintf(":%d", p)
 	}
 
+	cacheConfig := CacheConfig{
+		DefaultTTL: viper.GetDuration(CacheDefaultTTL),
+	}
+
 	// Redis configuration
 	redisConfig := RedisConfig{
 		Address:         viper.GetString(RedisAddress),
@@ -107,6 +125,7 @@ func Load(path string) (*ServiceConfig, error) {
 
 	return &ServiceConfig{
 		ServerConfig: serverConfig,
+		CacheConfig:  cacheConfig,
 		RedisConfig:  redisConfig,
 	}, nil
 }

--- a/internal/pkg/config/model.go
+++ b/internal/pkg/config/model.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import "time"
@@ -8,6 +22,8 @@ const (
 	OpenSavesBucket  = "open_saves_bucket"
 	OpenSavesProject = "open_saves_project"
 	LogLevel         = "log_level"
+
+	CacheDefaultTTL = "cache_default_ttl"
 
 	RedisAddress         = "redis_address"
 	RedisMinIdleConns    = "redis_min_idle_conns"
@@ -20,6 +36,7 @@ const (
 
 type ServiceConfig struct {
 	ServerConfig
+	CacheConfig
 	RedisConfig
 }
 
@@ -30,6 +47,12 @@ type ServerConfig struct {
 	Bucket  string
 	Cache   string
 	Project string
+}
+
+// CacheConfig has configurations for caching control (not Redis specific).
+type CacheConfig struct {
+	// DefaultTTL is the default TTL for cached data.
+	DefaultTTL time.Duration
 }
 
 // RedisConfig as defined in https://pkg.go.dev/github.com/go-redis/redis/v8#Options


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/main/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/main/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**

/kind feat

**What this PR does / Why we need it**:

This changes the default expiration time (5 minutes) for Redis cache entries and a configuration entry to change the value.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #322 

**Special notes for your reviewer**:
