### PR TITLE
feat: add support for inequality filters

### DIFF
--- a/deploy/datastore/index.yaml
+++ b/deploy/datastore/index.yaml
@@ -13,3 +13,8 @@ indexes:
     direction: asc
   - name: Timestamps.UpdatedAt
     direction: asc
+
+- kind: record
+  ancestor: yes
+  properties:
+  - name: Properties.prop1

--- a/deploy/terraform/gcp/datastore.tf
+++ b/deploy/terraform/gcp/datastore.tf
@@ -17,11 +17,11 @@
 resource "google_datastore_index" "blob_status_updated_at" {
   kind = "blob"
   properties {
-    name = "Status"
+    name      = "Status"
     direction = "ASCENDING"
   }
   properties {
-    name = "Timestamps.UpdatedAt"
+    name      = "Timestamps.UpdatedAt"
     direction = "ASCENDING"
   }
 }
@@ -29,11 +29,24 @@ resource "google_datastore_index" "blob_status_updated_at" {
 resource "google_datastore_index" "chunk_status_updated_at" {
   kind = "chunk"
   properties {
-    name = "Status"
+    name      = "Status"
     direction = "ASCENDING"
   }
   properties {
-    name = "Timestamps.UpdatedAt"
+    name      = "Timestamps.UpdatedAt"
     direction = "ASCENDING"
+  }
+}
+
+resource "google_datastore_index" "default_indexed_properties" {
+  kind     = "record"
+  ancestor = "ALL_ANCESTORS"
+  properties {
+    name      = "Properties.prop1"
+    direction = "ASCENDING"
+  }
+  properties {
+    name      = "Properties.prop1"
+    direction = "DESCENDING"
   }
 }

--- a/internal/app/server/open_saves_test.go
+++ b/internal/app/server/open_saves_test.go
@@ -872,6 +872,7 @@ func TestOpenSaves_QueryRecords_InequalityFilter(t *testing.T) {
 	}
 	resp, err := client.QueryRecords(ctx, queryReq)
 	require.NoError(t, err)
+
 	// Both records match the query.
 	require.Equal(t, 2, len(resp.Records))
 	require.Equal(t, 2, len(resp.StoreKeys))
@@ -879,6 +880,16 @@ func TestOpenSaves_QueryRecords_InequalityFilter(t *testing.T) {
 	assert.Equal(t, storeKey, resp.StoreKeys[0])
 	assert.Equal(t, resp.Records[0].Properties["prop1"].Value, intVal1)
 	assert.Equal(t, resp.Records[1].Properties["prop1"].Value, intVal2)
+
+	// Run a new query that matches only one record.
+	queryReq.Filters[0].Value.Value = &pb.Property_IntegerValue{IntegerValue: 15}
+
+	resp, err = client.QueryRecords(ctx, queryReq)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(resp.Records))
+
+	assert.Equal(t, resp.Records[0].Properties["prop1"].Value, intVal2)
 }
 
 func TestOpenSaves_QueryRecords_Owner(t *testing.T) {

--- a/internal/pkg/metadb/metadb.go
+++ b/internal/pkg/metadb/metadb.go
@@ -685,14 +685,25 @@ func (m *MetaDB) GetChildChunkRefs(ctx context.Context, blobKey uuid.UUID) *chun
 	return chunkref.NewCursor(m.client.Run(ctx, query))
 }
 
+// addPropertyFilter augments a query with the QueryFilter operations.
 func addPropertyFilter(q *ds.Query, f *pb.QueryFilter) (*ds.Query, error) {
+	filter := propertiesField + "." + f.PropertyName
 	switch f.Operator {
 	case pb.FilterOperator_EQUAL:
-		return q.Filter(propertiesField+"."+f.PropertyName+"=", record.ExtractValue(f.Value)), nil
+		filter += "="
+	case pb.FilterOperator_GREATER:
+		filter += ">"
+	case pb.FilterOperator_LESS:
+		filter += "<"
+	case pb.FilterOperator_GREATER_OR_EQUAL:
+		filter += ">="
+	case pb.FilterOperator_LESS_OR_EQUAL:
+		filter += "<="
 	default:
 		// TODO(hongalex): implement inequality filters
-		return nil, status.Errorf(codes.Unimplemented, "only the equality operator is supported currently")
+		return nil, status.Errorf(codes.Unimplemented, "unknown filter operator detected: %+v", f.Operator)
 	}
+	return q.Filter(filter, record.ExtractValue(f.Value)), nil
 }
 
 // QueryRecords returns a list of records that match the given filters and their stores.

--- a/internal/pkg/metadb/metadb.go
+++ b/internal/pkg/metadb/metadb.go
@@ -700,7 +700,6 @@ func addPropertyFilter(q *ds.Query, f *pb.QueryFilter) (*ds.Query, error) {
 	case pb.FilterOperator_LESS_OR_EQUAL:
 		filter += "<="
 	default:
-		// TODO(hongalex): implement inequality filters
 		return nil, status.Errorf(codes.Unimplemented, "unknown filter operator detected: %+v", f.Operator)
 	}
 	return q.Filter(filter, record.ExtractValue(f.Value)), nil


### PR DESCRIPTION
**What type of PR is this?**
/kind feat

**What this PR does / Why we need it**:
Adds remaining support for inequality filters `<, >, <=, >=`. What this doesn't do is automatically create the datastore index required to support these. If these indexes are not created, `QueryRecords` will return an appropriate error from Datastore.

**Which issue(s) this PR fixes**:
Closes #336

**Special notes for your reviewer**:
