### PR TITLE
fix: UpdateRecord destroys blob

### DIFF
--- a/internal/app/server/open_saves.go
+++ b/internal/app/server/open_saves.go
@@ -197,8 +197,6 @@ func (s *openSavesServer) UpdateRecord(ctx context.Context, req *pb.UpdateRecord
 			r.OwnerID = updateTo.OwnerID
 			r.Properties = updateTo.Properties
 			r.Tags = updateTo.Tags
-			r.Blob = updateTo.Blob
-			r.BlobSize = updateTo.BlobSize
 			r.OpaqueString = updateTo.OpaqueString
 			return r, nil
 		})

--- a/internal/app/server/open_saves_test.go
+++ b/internal/app/server/open_saves_test.go
@@ -333,12 +333,11 @@ func TestOpenSaves_UpdateRecordSimple(t *testing.T) {
 		OwnerId: "owner",
 	})
 
-	const testBlobSize = int64(123)
 	updateReq := &pb.UpdateRecordRequest{
 		StoreKey: storeKey,
 		Record: &pb.Record{
 			Key:          recordKey,
-			BlobSize:     testBlobSize,
+			BlobSize:     123,
 			OpaqueString: "Lorem ipsum dolor sit amet, consectetur adipiscing elit,",
 		},
 	}
@@ -349,7 +348,7 @@ func TestOpenSaves_UpdateRecordSimple(t *testing.T) {
 	}
 	expected := &pb.Record{
 		Key:          recordKey,
-		BlobSize:     testBlobSize,
+		BlobSize:     0, // should be ignored
 		OpaqueString: "Lorem ipsum dolor sit amet, consectetur adipiscing elit,",
 		CreatedAt:    created.GetCreatedAt(),
 		UpdatedAt:    timestamppb.Now(),
@@ -707,6 +706,17 @@ func TestOpenSaves_InlineBlobSimple(t *testing.T) {
 	}
 
 	// Check the blob
+	verifyBlob(ctx, t, client, store.Key, record.Key, testBlob)
+
+	// UpdateRecord should retain the inline blob.
+	client.UpdateRecord(ctx, &pb.UpdateRecordRequest{
+		StoreKey: store.Key,
+		Record: &pb.Record{
+			Key:      record.Key,
+			BlobSize: 0,
+		},
+	})
+
 	verifyBlob(ctx, t, client, store.Key, record.Key, testBlob)
 
 	// Deletion test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/main/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/main/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
/kind fix

**What this PR does / Why we need it**:
Fix a bug where UpdateRecord destroys a blob attached to the record.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #305

**Special notes for your reviewer**:
