### PR TITLE
fix: remove defer statement closing listeners

### DIFF
--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -43,11 +43,6 @@ func Run(ctx context.Context, network string, cfg *config.ServiceConfig) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := lis.Close(); err != nil {
-			log.Errorf("Failed to close %s %s: %v\n", network, cfg.ServerConfig.Address, err)
-		}
-	}()
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/main/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/main/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
/kind fix

**What this PR does / Why we need it**:
Adding `srv.GracefulStop` closes the listeners and the defer statement closing these listeners is erroneous and generates errors.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
