### PR TITLE
fix: backward compatibility with numberofchunks

### DIFF
--- a/internal/pkg/metadb/blobref/blobref.go
+++ b/internal/pkg/metadb/blobref/blobref.go
@@ -71,16 +71,7 @@ func (b *BlobRef) Save() ([]datastore.Property, error) {
 // Load implements the Datastore PropertyLoadSaver interface and converts Datstore
 // properties to the Properties field.
 func (b *BlobRef) Load(ps []datastore.Property) error {
-        // ps_modified has been added to enable backward compatibility by creating 
-        // a new datastore array that replaces legacy "NumberOfChunks" with "ChunkCount". 
-        var ps_modified []datastore.Property
-        for _, p := range ps {
-                if p.Name == "NumberOfChunks" {
-                        p.Name = "ChunkCount"
-                }
-                ps_modified = append(ps_modified, p)
-        }
-	return datastore.LoadStruct(b, ps_modified)
+	return datastore.LoadStruct(b, ps)
 }
 
 // LoadKey implements the KeyLoader interface and sets the value to the Key field.

--- a/internal/pkg/metadb/blobref/blobref.go
+++ b/internal/pkg/metadb/blobref/blobref.go
@@ -71,7 +71,16 @@ func (b *BlobRef) Save() ([]datastore.Property, error) {
 // Load implements the Datastore PropertyLoadSaver interface and converts Datstore
 // properties to the Properties field.
 func (b *BlobRef) Load(ps []datastore.Property) error {
-	return datastore.LoadStruct(b, ps)
+        // ps_modified has been added to enable backward compatibility by creating 
+        // a new datastore array that replaces legacy "NumberOfChunks" with "ChunkCount". 
+        var ps_modified []datastore.Property
+        for _, p := range ps {
+                if p.Name == "NumberOfChunks" {
+                        p.Name = "ChunkCount"
+                }
+                ps_modified = append(ps_modified, p)
+        }
+	return datastore.LoadStruct(b, ps_modified)
 }
 
 // LoadKey implements the KeyLoader interface and sets the value to the Key field.

--- a/internal/pkg/metadb/record/record.go
+++ b/internal/pkg/metadb/record/record.go
@@ -85,14 +85,13 @@ func (r *Record) Save() ([]datastore.Property, error) {
 func (r *Record) Load(ps []datastore.Property) error {
         // ps_modified has been added to enable backward compatibility by creating 
         // a new datastore array that replaces legacy "NumberOfChunks" with "ChunkCount". 
-        var ps_modified []datastore.Property
-        for _, p := range ps {
+	for i, p := range ps {
                 if p.Name == "NumberOfChunks" {
-                        p.Name = "ChunkCount"
+                        ps[i].Name = "ChunkCount"
+			break
                 }
-                ps_modified = append(ps_modified, p)
         }
-	externalBlob, ps_modified, err := timestamps.LoadUUID(ps_modified, externalBlobPropertyName)
+	externalBlob, ps, err := timestamps.LoadUUID(ps, externalBlobPropertyName)
 	if err != nil {
 		return err
 	}
@@ -101,7 +100,7 @@ func (r *Record) Load(ps []datastore.Property) error {
 	// Initialize Properties because the default value is a nil map and there
 	// is no way to change it inside PropertyMap.Load().
 	r.Properties = make(PropertyMap)
-	return datastore.LoadStruct(r, ps_modified)
+	return datastore.LoadStruct(r, ps)
 }
 
 // LoadKey implements the KeyLoader interface and sets the value to the Key and StoreKey fields.

--- a/internal/pkg/metadb/record/record.go
+++ b/internal/pkg/metadb/record/record.go
@@ -83,8 +83,7 @@ func (r *Record) Save() ([]datastore.Property, error) {
 // Load implements the Datastore PropertyLoadSaver interface and converts Datastore
 // properties to corresponding struct fields.
 func (r *Record) Load(ps []datastore.Property) error {
-        // ps_modified has been added to enable backward compatibility by creating 
-        // a new datastore array that replaces legacy "NumberOfChunks" with "ChunkCount". 
+        // Added for backward compatibility.
 	for i, p := range ps {
                 if p.Name == "NumberOfChunks" {
                         ps[i].Name = "ChunkCount"

--- a/internal/pkg/metadb/record/record.go
+++ b/internal/pkg/metadb/record/record.go
@@ -83,7 +83,16 @@ func (r *Record) Save() ([]datastore.Property, error) {
 // Load implements the Datastore PropertyLoadSaver interface and converts Datastore
 // properties to corresponding struct fields.
 func (r *Record) Load(ps []datastore.Property) error {
-	externalBlob, ps, err := timestamps.LoadUUID(ps, externalBlobPropertyName)
+        // ps_modified has been added to enable backward compatibility by creating 
+        // a new datastore array that replaces legacy "NumberOfChunks" with "ChunkCount". 
+        var ps_modified []datastore.Property
+        for _, p := range ps {
+                if p.Name == "NumberOfChunks" {
+                        p.Name = "ChunkCount"
+                }
+                ps_modified = append(ps_modified, p)
+        }
+	externalBlob, ps_modified, err := timestamps.LoadUUID(ps_modified, externalBlobPropertyName)
 	if err != nil {
 		return err
 	}
@@ -92,7 +101,7 @@ func (r *Record) Load(ps []datastore.Property) error {
 	// Initialize Properties because the default value is a nil map and there
 	// is no way to change it inside PropertyMap.Load().
 	r.Properties = make(PropertyMap)
-	return datastore.LoadStruct(r, ps)
+	return datastore.LoadStruct(r, ps_modified)
 }
 
 // LoadKey implements the KeyLoader interface and sets the value to the Key and StoreKey fields.


### PR DESCRIPTION
What type of PR is this?
/kind fix

What this PR does / Why we need it:
This PR maps a legacy field called "NumberOfChunks" to the newly named "ChunkCount" field. This change was implemented against the record and blobref so that all downstream functions are able to reference "ChunkCount" without there being any naming conflict. 

Which issue(s) this PR fixes:  Backward compatibility issue with Record created with NumberOfChunks #391
https://github.com/googleforgames/open-saves/issues/391

Special notes for your reviewer: