### PR TITLE
test(timestamps): testify -> go-cmp, use table

### DIFF
--- a/internal/pkg/metadb/timestamps/timestamps_test.go
+++ b/internal/pkg/metadb/timestamps/timestamps_test.go
@@ -29,7 +29,7 @@ import (
 func TestTimestamps_NewTimestamps(t *testing.T) {
 	t.Parallel()
 
-	beforeNew := time.Now()
+	beforeNew := time.Now().Truncate(Precision)
 	ts := New()
 	afterNew := time.Now()
 
@@ -93,7 +93,7 @@ func TestTimestamps_Update(t *testing.T) {
 		UpdatedAt: testTime,
 		Signature: testUUID,
 	}
-	beforeUpdate := time.Now()
+	beforeUpdate := time.Now().Truncate(Precision)
 	ts.Update()
 	afterUpdate := time.Now()
 

--- a/internal/pkg/metadb/timestamps/timestamps_test.go
+++ b/internal/pkg/metadb/timestamps/timestamps_test.go
@@ -40,13 +40,13 @@ func TestTimestamps_NewTimestamps(t *testing.T) {
 
 	for _, got := range []time.Time{ts.CreatedAt, ts.UpdatedAt} {
 		if got.Location() != time.UTC {
-			t.Errorf("New(): timezone should be UTC, got = %v", got.Location())
+			t.Errorf("New() Location = got %v, want UTC", got.Location())
 		}
 		if !got.Equal(got.Truncate(Precision)) {
-			t.Errorf("New(): not truncated to %v, got = %v", Precision, got)
+			t.Errorf("New() = %v, should be truncated to %v", got, Precision)
 		}
 		if got.Before(beforeNew) || got.After(afterNew) {
-			t.Errorf("New(): should be between %v and %v, got = %v", beforeNew, afterNew, got)
+			t.Errorf("New() = %v,  want between %v and %v", got, beforeNew, afterNew)
 		}
 	}
 	if diff := cmp.Diff(ts.CreatedAt, ts.UpdatedAt); diff != "" {
@@ -101,13 +101,13 @@ func TestTimestamps_Update(t *testing.T) {
 		t.Errorf("Update() should not change CreatedAt, (-want, +got):\n%s", diff)
 	}
 	if got := ts.UpdatedAt.Location(); got != time.UTC {
-		t.Errorf("Update(): UpdatedAt should be in UTC, got = %v", got)
+		t.Errorf("Update() Location = got %v, want UTC", got)
 	}
 	if ts.UpdatedAt.Before(beforeUpdate) || ts.UpdatedAt.After(afterUpdate) {
-		t.Errorf("Update(): UpdatedAt should be between %v and %v, got = %v", beforeUpdate, afterUpdate, ts.UpdatedAt)
+		t.Errorf("Update() Updated At = %v, want between %v and %v", ts.UpdatedAt, beforeUpdate, afterUpdate)
 	}
 	if cmp.Equal(testUUID, ts.Signature) {
-		t.Errorf("Update() should update Signature, got = %v", ts.Signature)
+		t.Errorf("Update() Signature got = %v, want updated value", ts.Signature)
 	}
 }
 

--- a/internal/pkg/metadb/timestamps/uuid_test.go
+++ b/internal/pkg/metadb/timestamps/uuid_test.go
@@ -128,10 +128,10 @@ func TestUUID_LoadUUID(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			uuid, ps, err := LoadUUID(tc.props, tc.name)
 			if got := status.Code(err); got != tc.wantCode {
-				t.Errorf("LoadUUID(): returned status code %v, want %v", got, tc.wantCode)
+				t.Errorf("LoadUUID() status code got = %v, want %v", got, tc.wantCode)
 			}
 			if !cmp.Equal(tc.wantUUID, uuid) {
-				t.Errorf("LoadUUID() uuid = want %v, got %v", tc.wantUUID, uuid)
+				t.Errorf("LoadUUID() uuid = got %v, want%v", uuid, tc.wantUUID)
 			}
 			if diff := cmp.Diff(tc.wantProps, ps); diff != "" {
 				t.Errorf("LoadUUID() props = (-want, +got):\n%s", diff)


### PR DESCRIPTION

**What type of PR is this?**
/kind test

**What this PR does / Why we need it**:
This PR changes the timestamps tests to use go-cmp instead of tesitfy. Also rerrange tests to use table test cases.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
