### PR TITLE
feat: enable opencensus tracing with cloud trace for datastore

### DIFF
--- a/configs/service.yaml
+++ b/configs/service.yaml
@@ -1,17 +1,20 @@
 open_saves_port: 6000
-open_saves_cloud: "gcp"
-open_saves_bucket: ""
-open_saves_project: ""
-log_level: "info"
-shutdown_grace_period: "5s"
-cache_default_ttl: "5m"
+open_saves_cloud: 'gcp'
+open_saves_bucket: ''
+open_saves_project: ''
+log_level: 'info'
+shutdown_grace_period: '5s'
+cache_default_ttl: '5m'
 
-redis_address: "localhost:6379"
+redis_address: 'localhost:6379'
 redis_max_idle: 500
 redis_pool_size: 10000
 redis_idle_timeout: 0
 redis_max_retries: 3
-redis_min_retry_backoff: "8ms"
-redis_max_retry_backoff: "512ms"
+redis_min_retry_backoff: '8ms'
+redis_max_retry_backoff: '512ms'
 
 blob_max_inline_size: 65536
+
+enable_trace: true
+trace_sample_rate: 0.2

--- a/configs/service.yaml
+++ b/configs/service.yaml
@@ -16,5 +16,8 @@ redis_max_retry_backoff: '512ms'
 
 blob_max_inline_size: 65536
 
-enable_trace: true
-trace_sample_rate: 0.2
+# The following enables OpenCensus Tracing via Cloud Trace
+# for the Datastore client library.
+# It is EXPERIMENTAL and subject to change or removal without notice.
+enable_trace: false 
+trace_sample_rate: 0.00

--- a/configs/service.yaml
+++ b/configs/service.yaml
@@ -1,18 +1,17 @@
-open_saves_port: 6000
-open_saves_cloud: 'gcp'
-open_saves_bucket: ''
-open_saves_project: ''
-log_level: 'info'
-shutdown_grace_period: '5s'
-cache_default_ttl: '5m'
+open_saves_cloud: "gcp"
+open_saves_bucket: ""
+open_saves_project: ""
+log_level: "info"
+shutdown_grace_period: "5s"
+cache_default_ttl: "5m"
 
-redis_address: 'localhost:6379'
+redis_address: "localhost:6379"
 redis_max_idle: 500
 redis_pool_size: 10000
 redis_idle_timeout: 0
 redis_max_retries: 3
-redis_min_retry_backoff: '8ms'
-redis_max_retry_backoff: '512ms'
+redis_min_retry_backoff: "8ms"
+redis_max_retry_backoff: "512ms"
 
 blob_max_inline_size: 65536
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/datastore v1.8.0
+	contrib.go.opencensus.io/exporter/stackdriver v0.13.10
 	github.com/alicebob/miniredis/v2 v2.22.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang/mock v1.6.0
@@ -15,6 +16,7 @@ require (
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5
+	go.opencensus.io v0.23.0
 	gocloud.dev v0.25.0
 	google.golang.org/api v0.90.0
 	google.golang.org/grpc v1.48.0
@@ -26,11 +28,15 @@ require (
 	cloud.google.com/go v0.103.0 // indirect
 	cloud.google.com/go/compute v1.7.0 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
+	cloud.google.com/go/monitoring v1.4.0 // indirect
 	cloud.google.com/go/storage v1.24.0 // indirect
+	cloud.google.com/go/trace v1.2.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
+	github.com/aws/aws-sdk-go v1.43.31 // indirect
+	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -45,6 +51,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -60,11 +67,11 @@ require (
 	github.com/subosito/gotenv v1.4.0 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 // indirect
-	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/mod v0.5.0 // indirect
 	golang.org/x/net v0.0.0-20220728211354-c7608f3a8462 // indirect
 	golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c // indirect
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ cloud.google.com/go/iam v0.3.0/go.mod h1:XzJPvDayI+9zsASAFO68Hk07u3z+f+JrT2xXNdp
 cloud.google.com/go/kms v1.1.0/go.mod h1:WdbppnCDMDpOvoYBMn1+gNmOeEoZYqAv+HeuKARGCXI=
 cloud.google.com/go/kms v1.4.0/go.mod h1:fajBHndQ+6ubNw6Ss2sSd+SWvjL26RNo/dr7uxsnnOA=
 cloud.google.com/go/monitoring v1.1.0/go.mod h1:L81pzz7HKn14QCMaCs6NTQkdBnE87TElyanS95vIcl4=
+cloud.google.com/go/monitoring v1.4.0 h1:05+IuNMbh40hbxcqQ4SnynbwZbLG1Wc9dysIJxnfv7U=
 cloud.google.com/go/monitoring v1.4.0/go.mod h1:y6xnxfwI3hTFWOdkOaD7nfJVlwuC3/mS/5kvtT131p4=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
@@ -80,8 +81,10 @@ cloud.google.com/go/storage v1.23.0/go.mod h1:vOEEDNFnciUMhBeT6hsJIn3ieU5cFRmzeL
 cloud.google.com/go/storage v1.24.0 h1:a4N0gIkx83uoVFGz8B2eAV3OhN90QoWF5OZWLKl39ig=
 cloud.google.com/go/storage v1.24.0/go.mod h1:3xrJEFMXBsQLgxwThyjuD3aYlroL0TMRec1ypGUQ0KE=
 cloud.google.com/go/trace v1.0.0/go.mod h1:4iErSByzxkyHWzzlAj63/Gmjz0NH1ASqhJguHpGcr6A=
+cloud.google.com/go/trace v1.2.0 h1:oIaB4KahkIUOpLSAAjEJ8y2desbjY/x/RfP4O3KAtTI=
 cloud.google.com/go/trace v1.2.0/go.mod h1:Wc8y/uYyOhPy12KEnXG9XGrvfMz5F5SrYecQlbW1rwM=
 contrib.go.opencensus.io/exporter/aws v0.0.0-20200617204711-c478e41e60e9/go.mod h1:uu1P0UCM/6RbsMrgPa98ll8ZcHM858i/AD06a9aLRCA=
+contrib.go.opencensus.io/exporter/stackdriver v0.13.10 h1:a9+GZPUe+ONKUwULjlEOucMMG0qfSCCenlji0Nhqbys=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.10/go.mod h1:I5htMbyta491eUxufwwZPQdcKvvgzMB4O9ni41YnIM8=
 contrib.go.opencensus.io/integrations/ocsql v0.1.7/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -176,6 +179,7 @@ github.com/aws/smithy-go v1.11.2 h1:eG/N+CcUMAvsdffgMvjMKwfyDzIkjM6pfxMJ8Mzc6mE=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/census-instrumentation/opencensus-proto v0.3.0 h1:t/LhUZLVitR1Ow2YOnduCsavhwFUklBMoGVYUCqmCqk=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -416,6 +420,7 @@ github.com/jackc/puddle v1.2.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -719,6 +724,7 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/app/server/open_saves.go
+++ b/internal/app/server/open_saves.go
@@ -87,6 +87,8 @@ func newOpenSavesServer(ctx context.Context, cfg *config.ServiceConfig) (*openSa
 			ServiceConfig: *cfg,
 		}
 		if cfg.ServerConfig.EnableTrace {
+			rate := cfg.ServerConfig.TraceSampleRate
+			log.Printf("Enabling CloudTrace exporter with sample rate: %f\n", rate)
 			sd, err := stackdriver.NewExporter(stackdriver.Options{
 				ProjectID: cfg.Project,
 			})
@@ -98,7 +100,7 @@ func newOpenSavesServer(ctx context.Context, cfg *config.ServiceConfig) (*openSa
 
 			// Register it as a trace exporter
 			trace.RegisterExporter(sd)
-			trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(cfg.ServerConfig.TraceSampleRate)})
+			trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(rate)})
 		}
 		return server, nil
 	default:

--- a/internal/app/server/open_saves_test.go
+++ b/internal/app/server/open_saves_test.go
@@ -131,6 +131,7 @@ func TestOpenSaves_HealthCheck(t *testing.T) {
 }
 
 func TestOpenSaves_RunServer(t *testing.T) {
+	t.Skip()
 	serviceConfig, err := getServiceConfig()
 	if err != nil {
 		t.Fatalf("getServiceConfig err: %v", err)

--- a/internal/app/server/open_saves_test.go
+++ b/internal/app/server/open_saves_test.go
@@ -131,7 +131,6 @@ func TestOpenSaves_HealthCheck(t *testing.T) {
 }
 
 func TestOpenSaves_RunServer(t *testing.T) {
-	t.Skip()
 	serviceConfig, err := getServiceConfig()
 	if err != nil {
 		t.Fatalf("getServiceConfig err: %v", err)

--- a/internal/pkg/config/loader.go
+++ b/internal/pkg/config/loader.go
@@ -90,6 +90,7 @@ func Load(path string) (*ServiceConfig, error) {
 	if viper.GetString(RedisAddress) == "" {
 		log.Fatal("missing -cache argument for cache store")
 	}
+	log.Printf("trace: %b, rate: %d\n", viper.GetBool(EnableTrace), viper.GetFloat64(TraceSampleRate))
 
 	serverConfig := ServerConfig{
 		Address:             fmt.Sprintf(":%d", viper.GetUint(OpenSavesPort)),
@@ -97,6 +98,8 @@ func Load(path string) (*ServiceConfig, error) {
 		Bucket:              viper.GetString(OpenSavesBucket),
 		Project:             viper.GetString(OpenSavesProject),
 		ShutdownGracePeriod: viper.GetDuration(ShutdownGracePeriod),
+		EnableTrace:         viper.GetBool(EnableTrace),
+		TraceSampleRate:     viper.GetFloat64(TraceSampleRate),
 	}
 
 	// Cloud Run environment populates the PORT env var, so check for it here.

--- a/internal/pkg/config/loader.go
+++ b/internal/pkg/config/loader.go
@@ -90,7 +90,6 @@ func Load(path string) (*ServiceConfig, error) {
 	if viper.GetString(RedisAddress) == "" {
 		log.Fatal("missing -cache argument for cache store")
 	}
-	log.Printf("trace: %t, rate: %f\n", viper.GetBool(EnableTrace), viper.GetFloat64(TraceSampleRate))
 
 	serverConfig := ServerConfig{
 		Address:             fmt.Sprintf(":%d", viper.GetUint(OpenSavesPort)),

--- a/internal/pkg/config/loader.go
+++ b/internal/pkg/config/loader.go
@@ -90,7 +90,7 @@ func Load(path string) (*ServiceConfig, error) {
 	if viper.GetString(RedisAddress) == "" {
 		log.Fatal("missing -cache argument for cache store")
 	}
-	log.Printf("trace: %b, rate: %d\n", viper.GetBool(EnableTrace), viper.GetFloat64(TraceSampleRate))
+	log.Printf("trace: %t, rate: %f\n", viper.GetBool(EnableTrace), viper.GetFloat64(TraceSampleRate))
 
 	serverConfig := ServerConfig{
 		Address:             fmt.Sprintf(":%d", viper.GetUint(OpenSavesPort)),

--- a/internal/pkg/config/model.go
+++ b/internal/pkg/config/model.go
@@ -36,6 +36,9 @@ const (
 
 	BlobMaxInlineSize = "blob_max_inline_size"
 
+	// The following enables OpenCensus Tracing via Cloud Trace
+	// for the Datastore client library.
+	// It is EXPERIMENTAL and subject to change or removal without notice.
 	EnableTrace     = "enable_trace"
 	TraceSampleRate = "trace_sample_rate"
 )

--- a/internal/pkg/config/model.go
+++ b/internal/pkg/config/model.go
@@ -57,8 +57,11 @@ type ServerConfig struct {
 	Bucket              string
 	Project             string
 	ShutdownGracePeriod time.Duration
-	EnableTrace         bool
-	TraceSampleRate     float64
+	// The following enables OpenCensus Tracing via Cloud Trace
+	// for the Datastore client library.
+	// It is EXPERIMENTAL and subject to change or removal without notice.
+	EnableTrace     bool
+	TraceSampleRate float64
 }
 
 // CacheConfig has configurations for caching control (not Redis specific).

--- a/internal/pkg/config/model.go
+++ b/internal/pkg/config/model.go
@@ -35,6 +35,9 @@ const (
 	RedisMaxRetryBackoff = "redis_max_retry_backoff"
 
 	BlobMaxInlineSize = "blob_max_inline_size"
+
+	EnableTrace     = "enable_trace"
+	TraceSampleRate = "trace_sample_rate"
 )
 
 type ServiceConfig struct {
@@ -51,6 +54,8 @@ type ServerConfig struct {
 	Bucket              string
 	Project             string
 	ShutdownGracePeriod time.Duration
+	EnableTrace         bool
+	TraceSampleRate     float64
 }
 
 // CacheConfig has configurations for caching control (not Redis specific).


### PR DESCRIPTION
**What type of PR is this?**
> /kind feat

**What this PR does / Why we need it**:
Enables the default tracing provided by the Datastore client library, exporting to Cloud Trace. This allows us to view spans created by the Datastore client for transactions, viewing latency and some error metrics.

This change is EXPERIMENTAL and subject to change or removal without notice.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
