### PR TITLE
fix: remove extra writes when uploading chunked data

### DIFF
--- a/internal/app/collector/collector_test.go
+++ b/internal/app/collector/collector_test.go
@@ -35,10 +35,7 @@ const (
 	// TODO(yuryu): Make these configurable
 	testProject       = "triton-for-games-dev"
 	testBucket        = "gs://triton-integration"
-	testBufferSize    = 1024 * 1024
 	testCacheAddr     = "localhost:6379"
-	storeKind         = "store"
-	recordKind        = "record"
 	blobKind          = "blob"
 	chunkKind         = "chunk"
 	testTimeThreshold = -1 * time.Hour
@@ -120,10 +117,10 @@ func chunkRefKey(chunk *chunkref.ChunkRef) *datastore.Key {
 		datastore.NameKey(blobKind, chunk.BlobRef.String(), nil))
 }
 
-func setupTestChunkRef(ctx context.Context, t *testing.T, collector *Collector, ds *datastore.Client, chunk *chunkref.ChunkRef) {
+func setupTestChunkRef(ctx context.Context, t *testing.T, collector *Collector, ds *datastore.Client, blob *blobref.BlobRef, chunk *chunkref.ChunkRef) {
 	t.Helper()
 
-	if err := collector.metaDB.InsertChunkRef(ctx, chunk); err != nil {
+	if err := collector.metaDB.InsertChunkRef(ctx, blob, chunk); err != nil {
 		t.Fatalf("InsertChunkRef failed: %v", err)
 	}
 	t.Cleanup(func() {
@@ -254,7 +251,7 @@ func TestCollector_DeletesChunkedBlobs(t *testing.T) {
 	chunks[3].Fail()
 
 	for _, c := range chunks {
-		setupTestChunkRef(ctx, t, collector, ds, c)
+		setupTestChunkRef(ctx, t, collector, ds, blob, c)
 		setupExternalBlob(ctx, t, collector, c.ObjectPath())
 	}
 	collector.run(ctx)

--- a/internal/app/server/open_saves_test.go
+++ b/internal/app/server/open_saves_test.go
@@ -52,8 +52,8 @@ import (
 )
 
 const (
-	testProject             = "dev-triton"
-	testBucket              = "gs://dev-triton-coretech-online"
+	testProject             = "triton-for-games-dev"
+	testBucket              = "gs://triton-integration"
 	testPort                = "8000"
 	testBufferSize          = 1024 * 1024
 	testShutdownGracePeriod = "1s"

--- a/internal/app/server/open_saves_test.go
+++ b/internal/app/server/open_saves_test.go
@@ -52,8 +52,8 @@ import (
 )
 
 const (
-	testProject             = "triton-for-games-dev"
-	testBucket              = "gs://triton-integration"
+	testProject             = "dev-triton"
+	testBucket              = "gs://dev-triton-coretech-online"
 	testPort                = "8000"
 	testBufferSize          = 1024 * 1024
 	testShutdownGracePeriod = "1s"

--- a/internal/pkg/metadb/metadb.go
+++ b/internal/pkg/metadb/metadb.go
@@ -911,14 +911,10 @@ func (m *MetaDB) ValidateChunkRefPreconditions(ctx context.Context, chunk *chunk
 	return blob, nil
 }
 
-// InsertChunkRefAsReady inserts a new ChunkRef object to the datastore. If the current session has another chunk
+// InsertChunkRef inserts a new ChunkRef object to the datastore. If the current session has another chunk
 // with the same Number, it will be marked for deletion.
-func (m *MetaDB) InsertChunkRefAsReady(ctx context.Context, blob *blobref.BlobRef, chunk *chunkref.ChunkRef) error {
+func (m *MetaDB) InsertChunkRef(ctx context.Context, blob *blobref.BlobRef, chunk *chunkref.ChunkRef) error {
 	_, err := m.client.RunInTransaction(ctx, func(tx *ds.Transaction) error {
-		if err := chunk.Ready(); err != nil {
-			return err
-		}
-		chunk.Timestamps.Update()
 
 		mut := ds.NewInsert(m.createChunkRefKey(chunk.BlobRef, chunk.Key), chunk)
 		if err := m.mutateSingleInTransaction(tx, mut); err != nil {


### PR DESCRIPTION
/kind fix

**What this PR does / Why we need it**:
During chunk upload, open saves is doing multiple write operations on the same chunk entity. We have removed one write to follow best practices for Datastore and reduce database contention.

**Which issue(s) this PR fixes**:
Closes #403 

**Special notes for your reviewer**:
