### PR TITLE
chore: bump minimum go version to 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # This base builder image will also used by Cloud Build.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.18 AS builder
+FROM golang:1.20 AS builder
 
 ENV PROTOC_VERSION=21.3
 ENV GO111MODULE=on
@@ -60,7 +60,7 @@ RUN apk add --no-cache ca-certificates
 # Copy the binary to the production image from the builder stage.
 COPY --from=amd64 /src/open-saves/build/collector /collector
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.12 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.22 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
 
@@ -80,7 +80,7 @@ RUN apk add --no-cache ca-certificates
 COPY --from=amd64 /src/open-saves/build/server /server
 COPY --from=amd64 /src/open-saves/configs /configs
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.12 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.22 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
     waitFor:
       - "prep"
 substitutions:
-  _BUILDER: "us-docker.pkg.dev/${PROJECT_ID}/open-saves-builder/open-saves-builder:1.18"
+  _BUILDER: "us-docker.pkg.dev/${PROJECT_ID}/open-saves-builder/open-saves-builder:1.20"
 options:
   volumes:
     - name: gopath

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleforgames/open-saves
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go/datastore v1.11.0


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What this PR does / Why we need it**:

Addresses vulnerabilities that are fixed in go 1.20
Stable versions of go are the last two minor versions, go 1.20 and 1.21 

**Special notes for your reviewer**:
