### PR TITLE
fix: Change Redis.go to support explicitely connecting to a Redis Cluster with a single address for GCP compatibility

### DIFF
--- a/configs/service.yaml
+++ b/configs/service.yaml
@@ -5,6 +5,10 @@ log_level: "info"
 shutdown_grace_period: "5s"
 cache_default_ttl: "5m"
 
+# When working with a single Redis instance, set redis_mode: "single" and supply a single address.
+# When working with Redis Cluster, set redis_mode: "cluster"
+#  - if it is a standard Redis Cluster, supply a list of IPs separated by (,)
+#  - if it is a GCP MemoryStore Redis Cluster, supply a single address - the discovery address.
 redis_address: "localhost:6379"
 redis_mode: "single"
 redis_min_idle_conns: 500

--- a/configs/service.yaml
+++ b/configs/service.yaml
@@ -6,6 +6,7 @@ shutdown_grace_period: "5s"
 cache_default_ttl: "5m"
 
 redis_address: "localhost:6379"
+redis_mode: "single"
 redis_min_idle_conns: 500
 redis_pool_size: 10000
 redis_idle_timeout: 0

--- a/internal/app/collector/collector.go
+++ b/internal/app/collector/collector.go
@@ -34,11 +34,12 @@ import (
 
 // Config defines common fields needed to start the garbage collector.
 type Config struct {
-	Cloud   string
-	Bucket  string
-	Cache   string
-	Project string
-	Before  time.Time
+	Cloud     string
+	Bucket    string
+	Cache     string
+	RedisMode string
+	Project   string
+	Before    time.Time
 }
 
 // Collector is a garbage collector of unused resources in Datastore.
@@ -65,7 +66,11 @@ func newCollector(ctx context.Context, cfg *Config) (*Collector, error) {
 			log.Fatalf("Failed to create a MetaDB instance: %v", err)
 			return nil, err
 		}
-		cache := cache.New(redis.NewRedis(cfg.Cache), &config.CacheConfig{})
+		redisCfg := config.RedisConfig{
+			Address: cfg.Cache,
+			RedisMode: cfg.RedisMode,
+		}
+		cache := cache.New(redis.NewRedisWithConfig(&redisCfg), &config.CacheConfig{})
 		c := &Collector{
 			blob:   gcs,
 			metaDB: metadb,

--- a/internal/app/collector/collector_test.go
+++ b/internal/app/collector/collector_test.go
@@ -21,6 +21,7 @@ import (
 
 	"cloud.google.com/go/datastore"
 	"github.com/google/uuid"
+	"github.com/googleforgames/open-saves/internal/pkg/cache/redis"
 	"github.com/googleforgames/open-saves/internal/pkg/metadb/blobref"
 	"github.com/googleforgames/open-saves/internal/pkg/metadb/blobref/chunkref"
 	"github.com/googleforgames/open-saves/internal/pkg/metadb/record"
@@ -36,6 +37,7 @@ const (
 	testProject       = "triton-for-games-dev"
 	testBucket        = "gs://triton-integration"
 	testCacheAddr     = "localhost:6379"
+	testRedisMode     = redis.RedisModeSingle
 	blobKind          = "blob"
 	chunkKind         = "chunk"
 	testTimeThreshold = -1 * time.Hour
@@ -44,11 +46,12 @@ const (
 func newTestCollector(ctx context.Context, t *testing.T) *Collector {
 	t.Helper()
 	cfg := &Config{
-		Cloud:   "gcp",
-		Bucket:  testBucket,
-		Project: testProject,
-		Cache:   testCacheAddr,
-		Before:  time.Now().Add(testTimeThreshold),
+		Cloud:     "gcp",
+		Bucket:    testBucket,
+		Project:   testProject,
+		Cache:     testCacheAddr,
+		RedisMode: testRedisMode,
+		Before:    time.Now().Add(testTimeThreshold),
 	}
 	c, err := newCollector(ctx, cfg)
 	if err != nil {

--- a/internal/pkg/cache/redis/redis.go
+++ b/internal/pkg/cache/redis/redis.go
@@ -57,7 +57,7 @@ func NewRedisWithConfig(cfg *config.RedisConfig) *Redis {
 		o := &redis.ClusterOptions{
 			// When working with a standard Redis Cluster, it is expected the address being a list of addresses separated by commas (,)
 			// When working with CGP MemoryStore Redis Cluster, it is expected the address being a single address - the discovery address.
-			Addrs:           parseRedisClusterMultiAddress(cfg.Address),
+			Addrs:           parseRedisCluster(cfg.Address),
 			MinIdleConns:    cfg.MinIdleConns,
 			PoolSize:        cfg.PoolSize,
 			ConnMaxIdleTime: cfg.IdleTimeout,
@@ -95,8 +95,8 @@ func NewRedisWithConfig(cfg *config.RedisConfig) *Redis {
 	}
 }
 
-// parseRedisClusterMultiAddress Parse the input Redis address by splitting the list of addresses separated by commas (,)
-func parseRedisClusterMultiAddress(address string) []string {
+// parseRedisCluster Parse the input Redis address by splitting the list of addresses separated by commas (,)
+func parseRedisCluster(address string) []string {
 	addresses := []string{}
 
 	for _, foundAddr := range strings.Split(address, redisClusterSeparator) {

--- a/internal/pkg/cache/redis/redis.go
+++ b/internal/pkg/cache/redis/redis.go
@@ -57,7 +57,7 @@ func NewRedisWithConfig(cfg *config.RedisConfig) *Redis {
 		o := &redis.ClusterOptions{
 			// When working with a standard Redis Cluster, it is expected the address being a list of addresses separated by commas (,)
 			// When working with CGP MemoryStore Redis Cluster, it is expected the address being a single address - the discovery address.
-			Addrs:           parseRedisCluster(cfg.Address),
+			Addrs:           parseRedisAddress(cfg.Address),
 			MinIdleConns:    cfg.MinIdleConns,
 			PoolSize:        cfg.PoolSize,
 			ConnMaxIdleTime: cfg.IdleTimeout,
@@ -95,8 +95,8 @@ func NewRedisWithConfig(cfg *config.RedisConfig) *Redis {
 	}
 }
 
-// parseRedisCluster Parse the input Redis address by splitting the list of addresses separated by commas (,)
-func parseRedisCluster(address string) []string {
+// parseRedisAddress Parse the input Redis address by splitting the list of addresses separated by commas (,)
+func parseRedisAddress(address string) []string {
 	addresses := []string{}
 
 	for _, foundAddr := range strings.Split(address, redisClusterSeparator) {

--- a/internal/pkg/cache/redis/redis.go
+++ b/internal/pkg/cache/redis/redis.go
@@ -55,6 +55,8 @@ func NewRedisWithConfig(cfg *config.RedisConfig) *Redis {
 
 	if cfg.RedisMode == RedisModeCluster {
 		o := &redis.ClusterOptions{
+			// When working with a standard Redis Cluster, it is expected the address being a list of addresses separated by commas (,)
+			// When working with CGP MemoryStore Redis Cluster, it is expected the address being a single address - the discovery address.
 			Addrs:           parseRedisClusterMultiAddress(cfg.Address),
 			MinIdleConns:    cfg.MinIdleConns,
 			PoolSize:        cfg.PoolSize,
@@ -66,6 +68,7 @@ func NewRedisWithConfig(cfg *config.RedisConfig) *Redis {
 	} else {
 		// By default, if no RedisMode is supplied, Single mode will be selected.
 		// This is to be retro compatible with previous versions of OpenSaves.
+		// In this case the address is expected to be a single address.
 		o := &redis.Options{
 			Addr:            cfg.Address,
 			MinIdleConns:    cfg.MinIdleConns,

--- a/internal/pkg/cache/redis/redis_test.go
+++ b/internal/pkg/cache/redis/redis_test.go
@@ -146,7 +146,7 @@ func TestRedisParseRedisAddress(t *testing.T) {
 	}
 
 	for _, test := range fixture {
-		result := parseRedisClusterMultiAddress(test.address)
+		result := parseRedisCluster(test.address)
 
 		require.Equal(t, test.expected, result)
 	}

--- a/internal/pkg/cache/redis/redis_test.go
+++ b/internal/pkg/cache/redis/redis_test.go
@@ -146,7 +146,7 @@ func TestRedisParseRedisAddress(t *testing.T) {
 	}
 
 	for _, test := range fixture {
-		result := parseRedisCluster(test.address)
+		result := parseRedisAddress(test.address)
 
 		require.Equal(t, test.expected, result)
 	}

--- a/internal/pkg/cache/redis/redis_test.go
+++ b/internal/pkg/cache/redis/redis_test.go
@@ -16,8 +16,8 @@ package redis
 
 import (
 	"context"
-	"fmt"
 	"github.com/alicebob/miniredis/v2"
+	"github.com/googleforgames/open-saves/internal/pkg/config"
 	redis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,7 +75,11 @@ func TestRedis_ClusterAll(t *testing.T) {
 	// Use miniredis for tests.
 	s := miniredis.RunT(t)
 	// Configure Redis to use the cluster client.
-	r := NewRedis(fmt.Sprintf("cluster/%s",s.Addr()))
+	cfg := config.RedisConfig {
+		Address: s.Addr(),
+		RedisMode: RedisModeCluster,
+	}
+	r := NewRedisWithConfig(&cfg)
 	require.NotNil(t, r)
 	// Assert that we are getting a ClusterClient.
 	assert.IsType(t, &redis.ClusterClient{}, r.c)
@@ -128,10 +132,6 @@ func TestRedisParseRedisAddress(t *testing.T) {
 		{
 			address:  "redis:6379",
 			expected: []string{"redis:6379"},
-		},// Single address with prefix.
-		{
-			address:  "cluster/redis:6379",
-			expected: []string{"redis:6379"},
 		},
 		// Multiple addresses, no whitespaces.
 		{
@@ -141,11 +141,6 @@ func TestRedisParseRedisAddress(t *testing.T) {
 		// Multiple addresses, with whitespaces.
 		{
 			address:  "   redis-1:6379    ,    redis-2:6379   ",
-			expected: []string{"redis-1:6379", "redis-2:6379"},
-		},
-		// Multiple addresses, with prefix.
-		{
-			address:  "cluster/redis-1:6379,redis-2:6379",
 			expected: []string{"redis-1:6379", "redis-2:6379"},
 		},
 	}

--- a/internal/pkg/config/loader.go
+++ b/internal/pkg/config/loader.go
@@ -124,6 +124,7 @@ func Load(path string) (*ServiceConfig, error) {
 	// Redis configuration
 	redisConfig := RedisConfig{
 		Address:         viper.GetString(RedisAddress),
+		RedisMode:       viper.GetString(RedisMode),
 		MaxRetries:      viper.GetInt(RedisMaxRetries),
 		MinRetyBackoff:  viper.GetDuration(RedisMinRetryBackoff),
 		MaxRetryBackoff: viper.GetDuration(RedisMaxRetryBackoff),

--- a/internal/pkg/config/model.go
+++ b/internal/pkg/config/model.go
@@ -27,6 +27,7 @@ const (
 	CacheDefaultTTL = "cache_default_ttl"
 
 	RedisAddress         = "redis_address"
+	RedisMode            = "redis_mode"
 	RedisMinIdleConns    = "redis_min_idle_conns"
 	RedisPoolSize        = "redis_pool_size"
 	RedisIdleTimeout     = "redis_idle_timeout"
@@ -85,6 +86,7 @@ type CacheConfig struct {
 // RedisConfig as defined in https://pkg.go.dev/github.com/redis/go-redis/v9#Options
 type RedisConfig struct {
 	Address string
+	RedisMode string
 
 	MaxRetries      int
 	MinRetyBackoff  time.Duration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/main/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/main/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind feat
> /kind build
> /kind chore
> /kind ci
> /kind docs
> /kind style
> /kind refactor
> /kind perf
> /kind test

/kind fix

**What this PR does / Why we need it**:
When testing Redis connection with GCP managed Redis Cluster we've seen that GCP expects clients to connect using a single discovery IP instead of the set of IPs that is expected by Go-Redis UniversalClient.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #449

**Special notes for your reviewer**:
