### PR TITLE
feat: Bump up Golang version to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # This base builder image will also used by Cloud Build.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.21 AS builder
+FROM golang:1.23 AS builder
 
 ENV PROTOC_VERSION=21.3
 ENV GO111MODULE=on

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
     waitFor:
       - "prep"
 substitutions:
-  _BUILDER: "us-docker.pkg.dev/${PROJECT_ID}/open-saves-builder/open-saves-builder:1.21"
+  _BUILDER: "us-docker.pkg.dev/${PROJECT_ID}/open-saves-builder/open-saves-builder:1.23"
 options:
   volumes:
     - name: gopath


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What this PR does / Why we need it**:
Bump Golang version to 1.23 for open-saves-builder. 

**Which issue(s) this PR fixes**:
https://github.com/googleforgames/open-saves/pull/461#issuecomment-2736721923

