### PR TITLE
fix: Rename datastore_tx_max_retries to datastore_tx_max_attempts

### DIFF
--- a/cmd/collector/async/main.go
+++ b/cmd/collector/async/main.go
@@ -19,7 +19,7 @@ func main() {
 	defaultLogLevel := cmd.GetEnvVarString("OPEN_SAVES_LOG_LEVEL", "info")
 	defaultLogFormat := cmd.GetEnvVarString("OPEN_SAVES_LOG_FORMAT", "json")
 	defaultLogFile := cmd.GetEnvVarString("OPEN_SAVES_LOG_FILE", "")
-	defaultDatastoreTXMaxRetries := cmd.GetEnvVarUInt("OPEN_SAVES_DATASTORE_TX_MAX_RETRIES", 1)
+	defaultDatastoreTXMaxAttempts := cmd.GetEnvVarUInt("OPEN_SAVES_DATASTORE_TX_MAX_ATTEMPTS", 2)
 
 	var (
 		port                  = flag.String("port", defaultPort, "Port where new events will be listened for")
@@ -29,7 +29,7 @@ func main() {
 		logLevel              = flag.String("log-level", defaultLogLevel, "Minimum Log level")
 		logFormat             = flag.String("log-format", defaultLogFormat, "Minimum Log format")
 		logFile               = flag.String("log-file", defaultLogFile, "Log file to write the logs, if missing then it will write into stderr")
-		datastoreTXMaxRetries = flag.Int("datastore-tx-max-retries", int(defaultDatastoreTXMaxRetries), "Max retries attempt when using Datastore TX")
+		datastoreTXMaxAttempts = flag.Int("datastore-tx-max-attempts", int(defaultDatastoreTXMaxAttempts), "Max attempts when using Datastore TX")
 	)
 
 	flag.Parse()
@@ -40,7 +40,7 @@ func main() {
 		Bucket:                *bucket,
 		Project:               *project,
 		LogLevel:              *logLevel,
-		DatastoreTXMaxRetries: *datastoreTXMaxRetries,
+		DatastoreTXMaxAttempts: *datastoreTXMaxAttempts,
 	}
 
 	// Initialize writing the logs into a file.

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -34,7 +34,7 @@ func main() {
 	defaultExpiration := cmd.GetEnvVarDuration("OPEN_SAVES_GARBAGE_EXPIRATION", 24*time.Hour)
 	defaultLogLevel := cmd.GetEnvVarString("OPEN_SAVES_LOG_LEVEL", "info")
 	defaultLogFormat := cmd.GetEnvVarString("OPEN_SAVES_LOG_FORMAT", "json")
-	defaultDatastoreTXMaxRetries := cmd.GetEnvVarUInt("OPEN_SAVES_DATASTORE_TX_MAX_RETRIES", 1)
+	defaultDatastoreTXMaxAttempts := cmd.GetEnvVarUInt("OPEN_SAVES_DATASTORE_TX_MAX_ATTEMPTS", 2)
 
 	var (
 		cloud                 = flag.String("cloud", defaultCloud, "The public cloud provider you wish to run Open Saves on")
@@ -45,7 +45,7 @@ func main() {
 		expiration            = flag.Duration("garbage-expiration", defaultExpiration, "Collector deletes entries older than this time.Duration value (e.g. \"24h\")")
 		logLevel              = flag.String("log-level", defaultLogLevel, "Minimum Log level")
 		logFormat             = flag.String("log-format", defaultLogFormat, "Minimum Log format")
-		datastoreTXMaxRetries = flag.Int("datastore-tx-max-retries", int(defaultDatastoreTXMaxRetries), "Max retries attempt when using Datastore TX")
+		datastoreTXMaxAttempts = flag.Int("datastore-tx-max-attempts", int(defaultDatastoreTXMaxAttempts), "Max attempts when using Datastore TX")
 	)
 
 	flag.Parse()
@@ -71,7 +71,7 @@ func main() {
 		RedisMode:             *redisMode,
 		Before:                time.Now().Add(-*expiration),
 		LogLevel:              *logLevel,
-		DatastoreTXMaxRetries: *datastoreTXMaxRetries,
+		DatastoreTXMaxAttempts: *datastoreTXMaxAttempts,
 	}
 
 	// Configure the log format.

--- a/configs/service.yaml
+++ b/configs/service.yaml
@@ -34,4 +34,4 @@ enable_grpc_collector: false
 trace_service_name: "open-saves"
 trace_sample_rate: 0.00
 
-datastore_tx_max_retries: 1
+datastore_tx_max_attempts: 2

--- a/internal/app/collector/async/collector.go
+++ b/internal/app/collector/async/collector.go
@@ -38,7 +38,7 @@ type Config struct {
 	Bucket                string
 	Project               string
 	LogLevel              string
-	DatastoreTXMaxRetries int
+	DatastoreTXMaxAttempts int
 }
 
 // AsyncCollector represents the instance
@@ -67,7 +67,7 @@ func newCollector(ctx context.Context, cfg *Config) (*collector, error) {
 		if err != nil {
 			return nil, err
 		}
-		metadb, err := metadb.NewMetaDB(ctx, cfg.Project, config.DatastoreConfig{ TXMaxRetries: cfg.DatastoreTXMaxRetries})
+		metadb, err := metadb.NewMetaDB(ctx, cfg.Project, config.DatastoreConfig{ TXMaxAttempts: cfg.DatastoreTXMaxAttempts})
 		if err != nil {
 			log.Fatalf("Failed to create a MetaDB instance: %v", err)
 			return nil, err

--- a/internal/app/collector/collector.go
+++ b/internal/app/collector/collector.go
@@ -41,7 +41,7 @@ type Config struct {
 	Project               string
 	Before                time.Time
 	LogLevel              string
-	DatastoreTXMaxRetries int
+	DatastoreTXMaxAttempts int
 }
 
 // Collector is a garbage collector of unused resources in Datastore.
@@ -70,7 +70,7 @@ func newCollector(ctx context.Context, cfg *Config) (*Collector, error) {
 		if err != nil {
 			return nil, err
 		}
-		metadb, err := metadb.NewMetaDB(ctx, cfg.Project, config.DatastoreConfig{ TXMaxRetries: cfg.DatastoreTXMaxRetries})
+		metadb, err := metadb.NewMetaDB(ctx, cfg.Project, config.DatastoreConfig{ TXMaxAttempts: cfg.DatastoreTXMaxAttempts})
 		if err != nil {
 			log.Fatalf("Failed to create a MetaDB instance: %v", err)
 			return nil, err

--- a/internal/pkg/config/loader.go
+++ b/internal/pkg/config/loader.go
@@ -151,7 +151,7 @@ func Load(path string) (*ServiceConfig, error) {
 	}
 
 	datastoreConfig := DatastoreConfig{
-		TXMaxRetries: viper.GetInt(DatastoreTXMaxRetries),
+		TXMaxAttempts: viper.GetInt(DatastoreTXMaxAttempts),
 	}
 
 	return &ServiceConfig{

--- a/internal/pkg/config/model.go
+++ b/internal/pkg/config/model.go
@@ -56,7 +56,7 @@ const (
 	TraceEnableGRPCCollector = "trace_enable_grpc_collector"
 	TraceEnableHTTPCollector = "trace_enable_http_collector"
 
-	DatastoreTXMaxRetries = "datastore_tx_max_retries"
+	DatastoreTXMaxAttempts = "datastore_tx_max_attempts"
 )
 
 type ServiceConfig struct {
@@ -130,5 +130,5 @@ type GRPCServerConfig struct {
 }
 
 type DatastoreConfig struct {
-	TXMaxRetries int
+	TXMaxAttempts int
 }

--- a/internal/pkg/metadb/metadb_test.go
+++ b/internal/pkg/metadb/metadb_test.go
@@ -49,7 +49,7 @@ const (
 	testNamespace = "datastore-unittests"
 )
 
-var defaultDatastoreConfig = config.DatastoreConfig{TXMaxRetries: 1}
+var defaultDatastoreConfig = config.DatastoreConfig{TXMaxAttempts: 1}
 
 func TestMetaDB_NewMetaDB(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
Rename datastore_tx_max_retries to datastore_tx_max_attempts to better signal the usage of the property

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/main/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/main/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**

/kind fix

**What this PR does / Why we need it**:
Changes the name of the datastore_tx_max_retries config to datastore_tx_max_attempts as in Datastore code we don't set the number of retries (number of times the code will be attempted after the first one) but the total number of attempts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #471
