### PR TITLE
chore: Make signature check to return FailedPrecondition instead of Abort to avoid triggering Datastore TX retries

### DIFF
--- a/internal/app/collector/async/collector_test.go
+++ b/internal/app/collector/async/collector_test.go
@@ -2,11 +2,12 @@ package asynccollector
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"cloud.google.com/go/datastore"
-	"github.com/cloudevents/sdk-go/v2/event"
 	protobuf "github.com/cloudevents/sdk-go/binding/format/protobuf/v2"
+	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/google/uuid"
 	"github.com/googleapis/google-cloudevents-go/cloud/datastoredata"
 	"github.com/googleforgames/open-saves/internal/pkg/metadb/blobref"
@@ -19,19 +20,35 @@ import (
 )
 
 const (
-	testProject       = "triton-for-games-dev"
-	testBucket        = "gs://triton-integration"
-	testCacheAddr     = "localhost:6379"
-	blobKind          = "blob"
-	chunkKind         = "chunk"
+	defaultTestProject = "triton-for-games-dev"
+	defaultTestBucket  = "gs://triton-integration"
+	testCacheAddr      = "localhost:6379"
+	blobKind           = "blob"
+	chunkKind          = "chunk"
 )
+
+func getTestProject() string {
+	if testProject, ok := os.LookupEnv("TEST_PROJECT_ID"); ok {
+		return testProject
+	}
+
+	return defaultTestProject
+}
+
+func getTestBucket() string {
+	if testBucket, ok := os.LookupEnv("TEST_BUCKET"); ok {
+		return testBucket
+	}
+
+	return defaultTestBucket
+}
 
 func newTestCollector(ctx context.Context, t *testing.T) *collector {
 	t.Helper()
 	cfg := &Config{
 		Cloud:     "gcp",
-		Bucket:    testBucket,
-		Project:   testProject,
+		Bucket:    getTestBucket(),
+		Project:   getTestProject(),
 		LogLevel:  "debug",
 	}
 	c, err := newCollector(ctx, cfg)
@@ -59,7 +76,7 @@ func setupTestStore(ctx context.Context, t *testing.T, collector *collector) *st
 
 func newDatastoreClient(ctx context.Context, t *testing.T) *datastore.Client {
 	t.Helper()
-	ds, err := datastore.NewClient(ctx, testProject)
+	ds, err := datastore.NewClient(ctx, getTestProject())
 	if err != nil {
 		t.Fatalf("Failed to create a new Datastore client: %v", err)
 	}

--- a/internal/app/collector/collector_test.go
+++ b/internal/app/collector/collector_test.go
@@ -16,6 +16,7 @@ package collector
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -33,22 +34,37 @@ import (
 )
 
 const (
-	// TODO(yuryu): Make these configurable
-	testProject       = "triton-for-games-dev"
-	testBucket        = "gs://triton-integration"
-	testCacheAddr     = "localhost:6379"
-	testRedisMode     = redis.RedisModeSingle
-	blobKind          = "blob"
-	chunkKind         = "chunk"
-	testTimeThreshold = -1 * time.Hour
+	defaultTestProject = "triton-for-games-dev"
+	defaultTestBucket  = "gs://triton-integration"
+	testCacheAddr      = "localhost:6379"
+	testRedisMode      = redis.RedisModeSingle
+	blobKind           = "blob"
+	chunkKind          = "chunk"
+	testTimeThreshold  = -1 * time.Hour
 )
+
+func getTestProject() string {
+	if testProject, ok := os.LookupEnv("TEST_PROJECT_ID"); ok {
+		return testProject
+	}
+
+	return defaultTestProject
+}
+
+func getTestBucket() string {
+	if testBucket, ok := os.LookupEnv("TEST_BUCKET"); ok {
+		return testBucket
+	}
+
+	return defaultTestBucket
+}
 
 func newTestCollector(ctx context.Context, t *testing.T) *Collector {
 	t.Helper()
 	cfg := &Config{
 		Cloud:     "gcp",
-		Bucket:    testBucket,
-		Project:   testProject,
+		Bucket:    getTestBucket(),
+		Project:   getTestProject(),
 		Cache:     testCacheAddr,
 		RedisMode: testRedisMode,
 		Before:    time.Now().Add(testTimeThreshold),
@@ -78,7 +94,7 @@ func setupTestStore(ctx context.Context, t *testing.T, collector *Collector) *st
 
 func newDatastoreClient(ctx context.Context, t *testing.T) *datastore.Client {
 	t.Helper()
-	ds, err := datastore.NewClient(ctx, testProject)
+	ds, err := datastore.NewClient(ctx, getTestProject())
 	if err != nil {
 		t.Fatalf("Failed to create a new Datastore client: %v", err)
 	}

--- a/internal/app/server/open_saves.go
+++ b/internal/app/server/open_saves.go
@@ -193,7 +193,7 @@ func (s *openSavesServer) UpdateRecord(ctx context.Context, req *pb.UpdateRecord
 	newRecord, err := s.metaDB.UpdateRecord(ctx, req.GetStoreKey(), updateTo.Key,
 		func(r *record.Record) (*record.Record, error) {
 			if updateTo.Timestamps.Signature != uuid.Nil && r.Timestamps.Signature != updateTo.Timestamps.Signature {
-				return nil, status.Errorf(codes.Aborted, "Signature mismatch: expected (%v), actual (%v)",
+				return nil, status.Errorf(codes.FailedPrecondition, "Signature mismatch: expected (%v), actual (%v)",
 					updateTo.Timestamps.Signature.String(), r.Timestamps.Signature.String())
 			}
 			r.OwnerID = updateTo.OwnerID

--- a/internal/pkg/metadb/metadb.go
+++ b/internal/pkg/metadb/metadb.go
@@ -621,7 +621,7 @@ func (m *MetaDB) PromoteBlobRefWithRecordUpdater(ctx context.Context, blob *blob
 			return err
 		}
 		if updateTo.Timestamps.Signature != uuid.Nil && record.Timestamps.Signature != updateTo.Timestamps.Signature {
-			return status.Errorf(codes.Aborted, "Signature mismatch: expected (%v), actual (%v)",
+			return status.Errorf(codes.FailedPrecondition, "Signature mismatch: expected (%v), actual (%v)",
 				updateTo.Timestamps.Signature.String(), record.Timestamps.Signature.String())
 		}
 		if record.ExternalBlob == uuid.Nil {

--- a/internal/pkg/metadb/metadb_test.go
+++ b/internal/pkg/metadb/metadb_test.go
@@ -17,6 +17,7 @@ package metadb_test
 import (
 	"context"
 	"errors"
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -43,17 +44,25 @@ import (
 )
 
 const (
-	blobKind      = "blob"
-	chunkKind     = "chunk"
-	testProject   = "triton-for-games-dev"
-	testNamespace = "datastore-unittests"
+	blobKind           = "blob"
+	chunkKind          = "chunk"
+	defaultTestProject = "triton-for-games-dev"
+	testNamespace      = "datastore-unittests"
 )
 
 var defaultDatastoreConfig = config.DatastoreConfig{TXMaxAttempts: 1}
 
+func getTestProject() string {
+	if testProject, ok := os.LookupEnv("TEST_PROJECT_ID"); ok {
+		return testProject
+	}
+
+	return defaultTestProject
+}
+
 func TestMetaDB_NewMetaDB(t *testing.T) {
 	ctx := context.Background()
-	metaDB, err := m.NewMetaDB(ctx, testProject, defaultDatastoreConfig)
+	metaDB, err := m.NewMetaDB(ctx, getTestProject(), defaultDatastoreConfig)
 	assert.NotNil(t, metaDB, "NewMetaDB() should return a non-nil instance.")
 	assert.NoError(t, err, "NewMetaDB should succeed.")
 }
@@ -61,7 +70,7 @@ func TestMetaDB_NewMetaDB(t *testing.T) {
 const testTimestampThreshold = 30 * time.Second
 
 func newDatastoreClient(ctx context.Context, t *testing.T) *datastore.Client {
-	client, err := datastore.NewClient(ctx, testProject)
+	client, err := datastore.NewClient(ctx, getTestProject())
 	if err != nil {
 		t.Fatalf("datastore.NewClient() failed: %v", err)
 	}
@@ -73,7 +82,7 @@ func newDatastoreClient(ctx context.Context, t *testing.T) *datastore.Client {
 
 func newMetaDB(ctx context.Context, t *testing.T) *m.MetaDB {
 	t.Helper()
-	metaDB, err := m.NewMetaDB(ctx, testProject, defaultDatastoreConfig)
+	metaDB, err := m.NewMetaDB(ctx, getTestProject(), defaultDatastoreConfig)
 	if err != nil {
 		t.Fatalf("Initializing MetaDB: %v", err)
 	}


### PR DESCRIPTION
…

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-saves/blob/main/docs/contributing.md and developer guide https://github.com/googleforgames/open-saves/blob/main/docs/development.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind chore

**What this PR does / Why we need it**:
Changes the error code on Signature Mismatch to be FailedPrecondition instead of Abort to prevent Datastore TX retries.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #473

**Special notes for your reviewer**:
Also changed the way the TestProject and TestBucket is defined in the tests files to allow to override them using EnvVars.
Required for local testing of Devs who don't have access to the Google's dev projects.